### PR TITLE
Enable edit link

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -12,6 +12,10 @@ export default defineConfig({
       social: {
         github: "https://github.com/project-kessel",
       },
+      editLink: {
+        // This enables the "edit" link on the bottom of each page which directly links to contribute
+        baseUrl: 'https://github.com/project-kessel/docs/edit/main/',
+      },
       sidebar: [
         {
           label: "Start Here",


### PR DESCRIPTION
This enables the "edit this page" link on the bottom of each page. This is enabled on internal docs, but missed in public docs currently.