### PR TITLE
RHCLOUD-40283: add monitoring docs section

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -85,6 +85,18 @@ export default defineConfig({
           ]
         },
         {
+          label: "Monitoring Kessel",
+          collapsed: true,
+          items: [
+            {
+              label: "Inventory API",
+              items: [
+                'monitoring-kessel/inventory-api/monitoring-data-replication-inventory-api',
+              ]
+            },
+          ]
+        },
+        {
           label: "Contributing",
           collapsed: true,
           autogenerate: { directory: 'contributing' }

--- a/src/content/docs/monitoring-kessel/inventory-api/monitoring-data-replication-inventory-api.mdx
+++ b/src/content/docs/monitoring-kessel/inventory-api/monitoring-data-replication-inventory-api.mdx
@@ -1,0 +1,6 @@
+---
+title: "Monitoring Data Replication in Inventory API"
+description: "Metrics, Monitoring, and Alerting methods for Data Replication in Inventory API"
+---
+
+UNDER CONSTRUCTION


### PR DESCRIPTION
* Adds monitoring section for capturing useful info about monitoring kessel
* adds placeholder doc for data replication monitoring which will include any useful tooling/docs/links to internal docs for red hatters for SP's to take advantage as part of SP data replication epic effort but this is also useful for kessel reference in general