### PR TITLE
updates monitoring data replication doc, moves monitoring section under running kessel

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -81,19 +81,11 @@ export default defineConfig({
             {
               label: "Installation",
               autogenerate: { directory: 'running-kessel/installation' }
-            }
-          ]
-        },
-        {
-          label: "Monitoring Kessel",
-          collapsed: true,
-          items: [
-            {
-              label: "Inventory API",
-              items: [
-                'monitoring-kessel/inventory-api/monitoring-data-replication-inventory-api',
-              ]
             },
+            {
+              label: "Monitoring Kessel",
+              autogenerate: { directory: 'running-kessel/monitoring-kessel' }
+            }
           ]
         },
         {

--- a/src/content/docs/building-with-kessel/how-to/report-resources.mdx
+++ b/src/content/docs/building-with-kessel/how-to/report-resources.mdx
@@ -5,15 +5,16 @@ sidebar:
 ---
 
 import { Aside } from '@astrojs/starlight/components';
+import { LinkCard } from '@astrojs/starlight/components';
 
 <Aside title="Under Construction">We are working on improving this documentation</Aside>
 
 ## Using an Outbox
 Writing to your database and publishing events to a message broker are two distinct operations on external systems that
-cannot happen in an atomic manner (aka Dual Write Problem). This means that if your application crashes after writing 
-to the database but before publishing an asynchronous event, your database and any message consumers may become 
+cannot happen in an atomic manner (aka Dual Write Problem). This means that if your application crashes after writing
+to the database but before publishing an asynchronous event, your database and any message consumers may become
 permanently out of sync. The outbox pattern helps solve this problem by writing resource aggregates and messaging events
-within the same database transaction using an outbox table. When coupled with something like 
+within the same database transaction using an outbox table. When coupled with something like
 [Debezium](https://debezium.io/), the outbox table can be used to publish events to a message broker, ensuring that the
 database and messages are always (eventually) in sync.
 
@@ -34,23 +35,23 @@ CREATE TABLE outbox (
 **Column Breakdown:**
 
 - **id:** A unique identifier for each event, your primary key
-- **aggregatetype:** Describes the type of business entity that an event relates to, for example, customer or order. 
+- **aggregatetype:** Describes the type of business entity that an event relates to, for example, customer or order.
   This is used by Debezium to determine the destination topic.
 - **aggregateid:** The unique identifier of the specific entity instance, like the customer's ID or order number.
-- **payload:** The actual content of the event message, typically stored as JSON or JSONB for flexibility. This is what 
+- **payload:** The actual content of the event message, typically stored as JSON or JSONB for flexibility. This is what
   message consumers will receive.
 
 Additional columns can be added as needed, such as a `timestamp` for event creation or `operation` to indicate the type
-of operation (e.g., create, update, delete). There are [additional configurations](https://debezium.io/documentation/reference/stable/transformations/outbox-event-router.html#emitting-messages-with-additional-fields) 
-that need to be added to the debezium configuration if you'd like these fields to be mapped to headers or the payload 
+of operation (e.g., create, update, delete). There are [additional configurations](https://debezium.io/documentation/reference/stable/transformations/outbox-event-router.html#emitting-messages-with-additional-fields)
+that need to be added to the debezium configuration if you'd like these fields to be mapped to headers or the payload
 when producing messages.
 
 ### Writing to the Outbox
 
-With the outbox table in place, you'll need to modify your application's business logic to write to it within the same 
+With the outbox table in place, you'll need to modify your application's business logic to write to it within the same
 transaction as your primary data changes.
 
-For example, if you're creating a new customer and want to publish an event about it, you could consider your 
+For example, if you're creating a new customer and want to publish an event about it, you could consider your
 transaction looking something like this:
 
 ```sql
@@ -84,21 +85,22 @@ If you need to retain history for auditing, debugging, or recovery purposes, con
 
 **Outbox Event Creation**: Tracking the rate of event creation in combination with the rate of event consumption can help identify end-to-end lag in your system. If the outbox is filling up faster than it can be processed, you may need to scale your consumers or optimize your event processing logic.
 
-See [Monitoring Replication](/404) for more details on how to monitor your replication processes.
+See our **Monitoring Data Replication** guide for more details on how to monitor your replication processes.
+<LinkCard title="Monitoring Data Replication in Inventory API" href="/running-kessel/monitoring-kessel/monitoring-data-replication-inventory-api" />
 
 ### Beware: Write Skew
 
-Interleaved database writes could lead to 
-[write skew issues](https://www.cockroachlabs.com/blog/what-write-skew-looks-like/), where concurrent application 
-read-modify-write cycles could be operating on stale data causing silent corruption. It's advisable to take this into 
+Interleaved database writes could lead to
+[write skew issues](https://www.cockroachlabs.com/blog/what-write-skew-looks-like/), where concurrent application
+read-modify-write cycles could be operating on stale data causing silent corruption. It's advisable to take this into
 consideration when designing your outbox and event processing logic.
 
 ## Synchronizing Async Events with Postgres Listen/Notify
 
-For services that will produce asynchronous events downstream from a request handler and subsequently consume them as 
-apart of their replication pattern, a mechanism may be needed to signal when the event processing is complete. This 
-allows the initial request handler to wait for the outcome of the event consumption (e.g. replicating to kessel) before 
-proceeding or returning to the client. Postgres's [LISTEN](https://www.postgresql.org/docs/current/sql-listen.html)/[NOTIFY](https://www.postgresql.org/docs/current/sql-notify.html) 
+For services that will produce asynchronous events downstream from a request handler and subsequently consume them as
+apart of their replication pattern, a mechanism may be needed to signal when the event processing is complete. This
+allows the initial request handler to wait for the outcome of the event consumption (e.g. replicating to kessel) before
+proceeding or returning to the client. Postgres's [LISTEN](https://www.postgresql.org/docs/current/sql-listen.html)/[NOTIFY](https://www.postgresql.org/docs/current/sql-notify.html)
 features provide a lightweight solution for this synchronization.
 
 ### How it works
@@ -114,7 +116,7 @@ This approach effectively creates a synchronous workflow over an asynchronous wo
 ### Examples
 
 #### Listening on a Postgres channel
-To listen for notifications on a specific Postgres channel, you can use the `LISTEN` command. The example below listens 
+To listen for notifications on a specific Postgres channel, you can use the `LISTEN` command. The example below listens
 on the `host-replication` channel. Channels are arbitrarily defined strings that you can use to group related notifications.
 ```sql
 LISTEN "host-replication";
@@ -128,15 +130,15 @@ NOTIFY "host-replication", 'c0740fcd-c2a3-4767-b2d2-fd21cd12e31a';
 ```
 
 ### Considerations
-- LISTEN/NOTIFY may not be supported by all database drivers, you should double-check that your current postgres driver 
+- LISTEN/NOTIFY may not be supported by all database drivers, you should double-check that your current postgres driver
 can handle it.
 - Postgres channels are not durable, meaning that if the request handler is not actively listening when the NOTIFY is
 sent, it will miss the notification. Listening should be one of the first things you do in your request handler.
 - Postgres channels are not meant to be ephemeral, so you should not create and drop channels frequently. Instead, use a
- consistent channel name for each type of event you want to listen for. This means that you may have many listeners on 
- the same channel and your event/notification payloads should have some identifier to distinguish which event the 
+ consistent channel name for each type of event you want to listen for. This means that you may have many listeners on
+ the same channel and your event/notification payloads should have some identifier to distinguish which event the
  listener is interested in.
-- LISTEN/NOTIFY should use it's own pg connection, separate from the one used for your application logic. This is 
-because LISTEN/NOTIFY is a long-lived operation that can block other operations on the same connection. You should also 
-aim to minimize connections in a way that each new LISTEN does not produce a new connection, but rather reuses an 
+- LISTEN/NOTIFY should use it's own pg connection, separate from the one used for your application logic. This is
+because LISTEN/NOTIFY is a long-lived operation that can block other operations on the same connection. You should also
+aim to minimize connections in a way that each new LISTEN does not produce a new connection, but rather reuses an
 existing one.

--- a/src/content/docs/monitoring-kessel/inventory-api/monitoring-data-replication-inventory-api.mdx
+++ b/src/content/docs/monitoring-kessel/inventory-api/monitoring-data-replication-inventory-api.mdx
@@ -1,6 +1,0 @@
----
-title: "Monitoring Data Replication in Inventory API"
-description: "Metrics, Monitoring, and Alerting methods for Data Replication in Inventory API"
----
-
-UNDER CONSTRUCTION

--- a/src/content/docs/running-kessel/monitoring-kessel/monitoring-data-replication-inventory-api.mdx
+++ b/src/content/docs/running-kessel/monitoring-kessel/monitoring-data-replication-inventory-api.mdx
@@ -1,0 +1,68 @@
+---
+title: "Monitoring Data Replication in Inventory API"
+description: "Metrics, Monitoring, and Alerting methods for Data Replication in Inventory API"
+---
+
+## How Inventory API Ensures Data Consistency
+
+Inventory API uses a combination of [CDC](https://www.geeksforgeeks.org/change-data-capture-cdc/) and the [Outbox Pattern](https://www.geeksforgeeks.org/outbox-pattern-for-reliable-messaging-system-design/) to ensure internal data consistency, as well as consistent replication of Relations changes to SpiceDB. It does so by leveraging [Streams for Apache Kafka](https://developers.redhat.com/products/streams-for-apache-kafka/overview) and [Debezium](https://debezium.io/) to monitor changes in an outbox table in the Inventory API's database, and publish those events to a Kafka Topic. The events are then consumed by a Kafka Consumer client embedded in the Inventory API service, which handles creating or replicating changes to Relationships defined in SpiceDB for the given resource. Since events are ordered, they are processed in order, ensuring concurrent resource updates or failures do not create inconsistencies between Inventory and SpiceDB.
+
+The processes to ensure consistency means the addition of critical KPI's to monitor to ensure a stable and reliable service. For services that are planning to integrate with Kessel Inventory, the CDC/Outbox Pattern is an excellent way to ensure replication of changes to Inventory API. If you are looking to embark on your own CDC/Outbox journey, this guide should provide a good primer on the monitoring components critical to data consistency and replication between other services.
+
+## Key Performance Indicators (KPIs)
+
+Below are some of the key metrics we monitor to ensure consistency and replication aspects of Inventory API are functioning and healthy. This data is aggregated from a few data sources, including custom metrics defined in our service. Those leveraging a similar pattern using Kafka and Debezium would also benefit from monitoring these critical metrics.
+
+#### Message Processing Failure Rate:
+
+We compare the number of messages processed by Inventory API to the number of message processing errors to determine our failure rate. Note that processed messages are not just messages consumed from Kafka, but are processed by the application and then committed with Kafka as completed.
+
+#### Consumer Error Rate:
+
+Consumer Errors are errors related to the function of the Consumer client itself and its ability to interact with the Kafka broker. We monitor the rate of Consumer errors for higher-than-normal growth to ensure we are aware when the consumer client cannot process messages. When the consumer cannot process events, data replication is not occurring which could impact services/users relying on those changes.
+
+#### Kafka Error Rate:
+
+Kafka will publish errors related to the broker or interrelated components as events. We monitor the increase in Kafka error messages for the same reason we monitor consumer errors as it has direct impact on data replication.
+
+#### Consumer Lag and End-to-End Lag:
+
+Consumer lag is the difference between the last offset stored by the broker and the last committed offset for that partition. Lag can occur for a few reasons: network congestion, slow processing of events, errors in processing events, or Kafka-related errors to address are just some examples. Its a critical metric for understanding the performance of your data replication and knowing when problems arise or when its time to scale these components to keep up with the number of events to process.
+
+End-to-End Lag takes this a step further and captures the gap between when events are written to the outbox table to the consumer processing and commiting the event. The goal here being to capture if there are any bottle necks in the entire CDC/Outbox flow from start to finish.
+
+## Metrics Sources
+
+Inventory API leverages the following data sources for monitoring various components of the consistency flow. These metrics are aggregated into Prometheus for monitoring using Grafana for dashboards and alerting through Alertmanager.
+
+### librdkafka Internal Metrics
+
+librdkafka is a C library implementation of the Apache Kafka protocol, providing Producer, Consumer and Admin clients in numerous [languages](https://github.com/confluentinc/librdkafka/tree/master?tab=readme-ov-file#language-bindings). librdkafka-based clients can be configured to emit [internal metrics](https://github.com/confluentinc/librdkafka/blob/master/STATISTICS.md) as events, in which a service can capture and record these metrics in an external monitoring service, such as Prometheus.
+
+Inventory API leverages the Statistics metrics from our Kafka Consumer client to capture metrics on the client itself, as well as Kafka related components the client interacts with (topics, brokers, consumer groups, etc).
+
+### Streams for Apache Kafka Prometheus Configuration
+
+Streams for Apache Kafka can be [configured to expose metrics](https://docs.redhat.com/en/documentation/red_hat_streams_for_apache_kafka/2.9/html/deploying_and_managing_streams_for_apache_kafka_on_openshift/assembly-metrics-str#proc-metrics-kafka-deploy-options-str) for various Kafka related components, including the Kafka Connect cluster (where the Debezium connector runs) using the Prometheus JMX Exporter. These metrics provide more in-depth data about the Kafka infrastructure that we rely on as part of the CDC/Outbox pattern flow.
+
+Inventory API leverages Kafka Connect related metrics to understand the state of our Debezium connector and monitor its health.
+
+### Kafka Lag Exporter
+
+The [Kafka Lag Exporter](https://docs.redhat.com/en/documentation/red_hat_streams_for_apache_kafka/2.9/html/deploying_and_managing_streams_for_apache_kafka_on_openshift/assembly-metrics-str#con-metrics-kafka-exporter-lag-str) extracts additional metrics data from Kafka brokers related to offsets, consumer groups, consumer lag, and topics. It can also be configured through Streams for Apache Kafka and offers supplmental data similar to the librdkafka metrics.
+
+Inventory API leverages the Kafka Lag exporter to monitor lag between our consumer client process and message queue.
+
+### Custom Metrics
+
+While there is no shortage of ways to get metrics data from Kafka-related services, none are indicators of how your service is functioning with regards to publishing and processing events to ensure consistency and replication. Below are the custom metrics we have defined that help fill in the gaps.
+
+* **Messages Processed**: Counter that tracks events that are consumed and processed by the application and committed as completed. Used as part of capturing message processing failure rate
+* **Message Process Failures**: Counter to track whenever processing a message fails for any reason. Used as part of capturing message processing failure rate
+* **Consumer Errors**: Counter to track when the Consumer client fails for any reason. Used to calculate consumer error rates.
+* **Kafka Error Events**: Counter to track whenever a Kafka Error event is consumed for any reason. Used to calculate kafka error rates.
+* **Outbox Event Writes**: Counter to track when an event is written to the outbox table. Used for calculating end-to-end lag.
+
+## Alerting
+
+// TODO

--- a/src/content/docs/running-kessel/monitoring-kessel/monitoring-data-replication-inventory-api.mdx
+++ b/src/content/docs/running-kessel/monitoring-kessel/monitoring-data-replication-inventory-api.mdx
@@ -29,7 +29,7 @@ Kafka will publish errors related to the broker or interrelated components as ev
 
 Consumer lag is the difference between the last offset stored by the broker and the last committed offset for that partition. Lag can occur for a few reasons: network congestion, slow processing of events, errors in processing events, or Kafka-related errors to address are just some examples. Its a critical metric for understanding the performance of your data replication and knowing when problems arise or when its time to scale these components to keep up with the number of events to process.
 
-End-to-End Lag takes this a step further and captures the gap between when events are written to the outbox table to the consumer processing and commiting the event. The goal here being to capture if there are any bottle necks in the entire CDC/Outbox flow from start to finish.
+End-to-End Lag takes this a step further and captures the gap between when events are written to the outbox table to the consumer processing and committing the event. The goal here being to capture if there are any bottle necks in the entire CDC/Outbox flow from start to finish.
 
 ## Metrics Sources
 
@@ -49,7 +49,7 @@ Inventory API leverages Kafka Connect related metrics to understand the state of
 
 ### Kafka Lag Exporter
 
-The [Kafka Lag Exporter](https://docs.redhat.com/en/documentation/red_hat_streams_for_apache_kafka/2.9/html/deploying_and_managing_streams_for_apache_kafka_on_openshift/assembly-metrics-str#con-metrics-kafka-exporter-lag-str) extracts additional metrics data from Kafka brokers related to offsets, consumer groups, consumer lag, and topics. It can also be configured through Streams for Apache Kafka and offers supplmental data similar to the librdkafka metrics.
+The [Kafka Lag Exporter](https://docs.redhat.com/en/documentation/red_hat_streams_for_apache_kafka/2.9/html/deploying_and_managing_streams_for_apache_kafka_on_openshift/assembly-metrics-str#con-metrics-kafka-exporter-lag-str) extracts additional metrics data from Kafka brokers related to offsets, consumer groups, consumer lag, and topics. It can also be configured through Streams for Apache Kafka and offers supplemental data similar to the librdkafka metrics.
 
 Inventory API leverages the Kafka Lag exporter to monitor lag between our consumer client process and message queue.
 
@@ -67,4 +67,4 @@ While there is no shortage of ways to get metrics data from Kafka-related servic
 
 Our alerting strategy for monitoring data consistency and replication is to ensure our alerts directly align with our KPI's, plus some platform related monitoring (Database disk usage, Kubernetes metrics, etc).
 
-For Red Hat Service Provider teams implementing a similar CDC/Outbox setup, the Management Fabric Kessel team can provide some resources, templates, and tooling that may simplify some of this monitoring work for you. See our [Internal Guide](https://docs-internal-project-kessel-8b6149c673ff0ed030e64b614e2ee9fd39.pages.redhat.com/running-kessel/monitoring-kessel/monitoring-data-replication-inventory-api) for more info (requires Red Hat VPN to access).
+For Red Hat Service Provider teams implementing a similar CDC/Outbox setup, the Management Fabric Kessel team can provide some resources, templates, and tooling that may simplify some of this monitoring work for you. See our [Internal Guide](https://project-kessel.pages.redhat.com/docs-internal/running-kessel/monitoring-kessel/monitoring-data-replication-inventory-api/) for more info (requires Red Hat VPN to access).

--- a/src/content/docs/running-kessel/monitoring-kessel/monitoring-data-replication-inventory-api.mdx
+++ b/src/content/docs/running-kessel/monitoring-kessel/monitoring-data-replication-inventory-api.mdx
@@ -65,4 +65,6 @@ While there is no shortage of ways to get metrics data from Kafka-related servic
 
 ## Alerting
 
-// TODO
+Our alerting strategy for monitoring data consistency and replication is to ensure our alerts directly align with our KPI's, plus some platform related monitoring (Database disk usage, Kubernetes metrics, etc).
+
+For Red Hat Service Provider teams implementing a similar CDC/Outbox setup, the Management Fabric Kessel team can provide some resources, templates, and tooling that may simplify some of this monitoring work for you. See our [Internal Guide](https://docs-internal-project-kessel-8b6149c673ff0ed030e64b614e2ee9fd39.pages.redhat.com/running-kessel/monitoring-kessel/monitoring-data-replication-inventory-api) for more info (requires Red Hat VPN to access).


### PR DESCRIPTION
* Updates the monitoring data replication doc with details for service providers on how we monitor Inventory
  * Goal is to serve as documentation for SP's looking to implement similar CDC/Outbox patterns to integrate with Inventory and ensure data replication
* updates link to monitoring doc in report-resources doc for outbox writes
* removes extra white space in report-resources doc
* moves monitoring kessel folder under running-kessel


NOTE: the link to the internal guide in the alerting section is expected to fail for now until updates are made in internal docs repo. This is because I also plan to move that guide under the running kessel section and it is not currently. All other links should be working.
