### PR TITLE
RHCLOUD-41274: Add client SDK contributing guide

### DIFF
--- a/src/content/docs/contributing/client-libraries.mdx
+++ b/src/content/docs/contributing/client-libraries.mdx
@@ -1,0 +1,126 @@
+---
+title: Client SDK specification
+description: Guide to developing client libraries (SDKs) for Kessel.
+---
+
+import { Aside } from '@astrojs/starlight/components';
+
+Client SDKs are libraries developers use to integrate their code with Kessel over a network. These are valuable. They help developers integrate easily by abstracting the complexity of remote procedure calls. They simplify the jobs of operators, who can expect more consistent and resilient client behavior.
+
+However, creating them comes at a steep cost because they have to be maintained for as many languages as we support. To reduce this cost, client SDKs should be developed with utmost consistency in mind, from language to language. This consistency in turn also benefits the developer experience: each client SDK, well designed, is easier to understand across multiple languages.
+
+This document outlines the standard which we expect all client SDKs to follow. If you are contributing to a client SDK, please follow this standard. If you wish to introduce a new API to the clients, please first update this standard with multiple languages in mind. Then, implement the new API in the language(s) you need.
+
+## Specification
+
+### Scope
+
+- Libraries SHOULD be scoped to Kessel, not to an individual service. Consider libraries "Kessel SDKs" for a given language, more than a client of a specific API.
+  - This decouples developers, to some extent, to the architecture of Kessel, allowing the possibility to evolve without impacting their dependencies or client API.
+  - It allows libraries to coordinate among Kessel components where relevant (e.g. between RBAC & Inventory).
+
+### Protocols
+
+- Our primary protocol is gRPC, but it is not required
+- For gRPC services, HTTP REST should be supported, but not the default, for client libraries
+  - HTTP may not support all of the features of the corresponding gRPC API, e.g. streaming endpoints.
+
+### Client generation
+
+- Client "[stubs](<https://en.wikipedia.org/wiki/Stub_(distributed_computing)>)" SHOULD be generated from API specifications. Use [buf](https://buf.build/docs/cli/) tooling for gRPC APIs. Use [openapi-generator](https://openapi-generator.tech/) tooling for HTTP APIs.
+  - If relevant (e.g. Python, Typescript), interface definitions should be generated
+- Generation MUST be repeatable across different builds and developer machines. For example, plugins should be pulled in remotely, with pinned versions, so we do not rely on local environment setup which may differ from machine to machine.
+
+### Dependencies
+
+- Clients SHOULD minimize dependencies while balancing minimum usability
+- Required protocol dependencies SHOULD be transitively included. This includes anything for the client to work in the most basic sense, without considering any middleware like authentication etc. For example, this should generally only be gRPC or protobuf specific dependencies.
+- Dependencies not required for basic communication SHOULD NOT be transitively included.
+  - Specifically "vendored" packages are an exception. E.g. using 'kessel-client-spring' or 'kessel-client-quarkus' for a library that builds on top of the base client with Spring or Quarkus integrations is perfectly acceptable (and encouraged, for vendor specific integrations).
+  - If a package is not dedicated to a specific vendor or integration, the dependency SHOULD be optional. For example, if OAuth requires a third party library, then don't cause the third party library to be pulled in transitively (unless, again, the package is an alternative Kessel library explicitly named for including this dependency). The developer can include it if they need OAuth for their application.
+  - Some exceptions can be commonly used libraries designed for transitive import, such as the google-auth-\* libraries for various languages in support of gRPC, or cryptography libraries, etc. These SHOULD be used as a base (e.g. [python](https://github.com/googleapis/google-auth-library-python), [java](https://github.com/googleapis/google-auth-library-java)) for authentication middleware and SHOULD be included transitively where relevant.
+- Any non-optional dependencies included transitively MUST be _designed_ to be a library dependency. That means:
+  - It MUST follow a well documented versioning scheme which distinguishes between compatible and breaking changes (e.g. SemVer)
+  - It MUST be explicitly developed with the expectation of being depended on as a library.
+  - We MUST stay up to date to avoid CVE exposure and compatibility issues.
+- Clients MUST NOT depend on the server, and servers MUST NOT depend on client libraries, to prevent cyclic dependencies.
+
+<Aside>
+References for good library design:
+
+- Java: [https://blogs.oracle.com/javamagazine/post/designing-and-implementing-a-library](https://blogs.oracle.com/javamagazine/post/designing-and-implementing-a-library)
+- Go: [https://blog.chewxy.com/2020/01/30/library-design/](https://blog.chewxy.com/2020/01/30/library-design/)
+</Aside>
+
+### Client API
+
+- No additional abstractions are _required_ beyond what is generated by gRPC
+- Utility methods SHOULD be included to instantiate channels with best practices or convenient settings
+  - e.g. to include the auth method, keep alive settings
+  - Configuration should use common names, and common file formats (if applicable)
+- Reusable middleware or replication abstractions SHOULD be included
+- Utilities for creating common RBAC resource types SHOULD be included
+- Class, method names, and import hierarchy SHOULD be consistent from language to language. Before adding to or changing the API, it is strongly recommended to document the specification of this API, or make a reference implementation.
+
+#### Imports
+
+Most languages have some concept of a module or package hierarchy for imports, usually derived from the directory structure, file path, repository, etc. For the purpose of this spec we will use the term "package."
+
+The `prefix` of these imports may be language specific but MUST at least include "kessel" somewhere. It can simply be "kessel" unless that would violate language convention (e.g. Java or Go). Prefix SHOULD NOT include a specific service given the [scope](#scope) of libraries is not service specific. The prefix MUST be the same for all imports.
+
+The _suffixes_ of these imports SHOULD be consistent from language to language (aside from language-specific delimiters):
+
+- `{prefix}.{service}.{major_version}`: Package for code specific to service and API version, where `{service}` is the separately versioned service (e.g. "inventory" or "rbac") and `{major_version}` is the major revision of the API (e.g. v1beta2, v1, v2), such as generated client code.
+  - **Note:** this import may be controlled by the layout, package, or options declared in the proto spec of gRPC APIs. This means the proto needs to define these accordingly based on the proto's own package or option declarations.
+  - Hand-written code MAY be added to these package(s), if it is version-specific.
+    - This MAY depend on peer packages.
+    - For example, middleware or utilities which integrate with this version can be placed here (such as `{prefix}.rbac.v2` for easy Workspace lookups).
+  - `.rbac` (or any other `{service}`) may be nested for RBAC/service-specific utilities which are also specific to that service-API version.
+    - For example, `{prefix}.inventory.v1beta2.rbac` for creating SubjectReferences, ResourceReferences, etc, following RBAC's well-known schema).
+- `{prefix}.grpc`: Package for utility methods or middleware specific to gRPC and are therefore only coupled to gRPC versions, not to a service API version (e.g. generic gRPC authentication middleware code goes here).
+  - MUST NOT import anything from the other defined peer packages
+- `{prefix}.http`: Package for utility methods or middleware specific to HTTP (whatever the library used) and therefore coupled to that library (or language runtime), not to a specific API version.
+  - MUST NOT import anything from the other defined peer packages
+- `{prefix}.middleware`: Package for reusable middleware or utilities not specific to transport (e.g. gRPC) or API version.
+  - It is okay to couple middleware to a specific API version internally. If the API of the middleware needs to change itself in a breaking way, bump the [package's version](#releases-and-versioning).
+  - `.{integration}`: can be further nested if the middleware is only relevant to a particular integration (e.g. `middleware.django` or `middleware.spring`). Note treatment of [dependencies](#dependencies).
+
+**Occasionally, a piece of code is dependent on multiple boundaries** (such as RBAC _and_ a particular API version, or gRPC _and_ a particular integration). In these cases, use some language specific means to further delineate (such as sub-packages, files, classes, etc).
+
+#### `{service}.{major_version}` package
+
+- SHOULD expose a `ClientBuilder` for constructing channels and stubs using best practices and available middleware (e.g. authentication) specific to that service & major version.
+  - This SHOULD have a notion of "[default](<#defaults-(across-all-languages)>)" configuration which incorporates best practices generally, specific to that language, and which apply to that service-version. Different constructor permutations should allow applying these "defaults" easily.
+    - For example, in the Python reference implementation, the "default" configuration, when not using asyncio, uses single-threaded unary streams for a performance improvement.
+  - This SHOULD have a constructor which accepts a `Configuration` object which reads common configuration values, consistent from language to language (e.g. with the same common keys, same environment variables, etc).
+  - This SHOULD expose `build` methods which construct stubs for that API version.
+  - This MAY delegate or inherit from generic gRPC code in the `grpc` package.
+  - **Note:** Not all languages are consistent in their treatment of Channels, ChannelOptions, and Stub configuration. The `ClientBuilder` is meant to be consistent despite these differences, within reason.
+    - For example, in some languages (Python, Go), everything meaningful is configured on the Channel itself. In some languages (Java), the stub contains CallOptions. In some languages, the Channel provides built-in methods for configuring it. In other languages, you have to provide CallOptions yourself, etc.
+
+#### Defaults (across all languages)
+
+- Deadlines, retries, load balancing, and other network level behavior MUST NOT be specified by the client defaults, and instead defined by the server and discovered by the client through [service config](https://github.com/grpc/proposal/blob/master/A2-service-configs-in-dns.md). This keeps each client consistent, and allows this to be managed centrally.
+- One possible exception is [HTTP/2 Keepalive](https://grpc.io/docs/guides/keepalive/). This requires explicitly configuring the channel or stub on the client and is not available through service config.
+
+#### `grpc` package
+
+- SHOULD expose utility methods to construct `CallCredentials` relevant to recommended Kessel authentication methods (e.g. OAuth), following the same pattern as gRPC / google-auth-\* libraries for that language.
+
+#### Exceptions
+
+- If relevant for the language, Clients SHOULD each define their own top-level exception or error type which wraps errors which are NOT thrown by gRPC
+- gRPC exceptions SHOULD NOT be wrapped
+
+### Object lifecycle
+
+- The lifecycle of stubs and channels SHOULD be managed by the application (e.g. through the application's DI container)
+- The `ClientBuilder` code documentation, as well as our website documentation, SHOULD instruct developers to reuse Channels and Stubs, per [gRPC performance best practices](https://grpc.io/docs/guides/performance/).
+- We MAY provide convenience facilities for this, but these are not required. [Dependency](#dependencies) rules apply. Possible approaches include:
+  - Basic, zero-dependency globals accessible via the `ClientBuilder`, if a `cacheKey` is provided. This should either create a channel or stub with the provided configuration, or retrieve a cached one using the same key value. It is assumed that the same key is always used with the same configuration.
+  - Integrations with popular DI containers (e.g. Spring, CDI), either in separate branded libraries or with optional dependencies.
+
+## Releases and versioning
+
+- Each client library MUST be versioned independently, following SemVer and the conventions of that language's packaging ecosystem. This is because there is no one server or API version to correlate them too, and languages may have their own reasons for changes (e.g. CVE, API change, etc).
+- Each client library's release MUST be published to the central registry for that language


### PR DESCRIPTION
https://issues.redhat.com/browse/RHCLOUD-41274

This is mostly just a copy of the internal design doc. Let's make updates in subsequent PRs.

I made very slight changes, but one more significant change I made while reviewing is about keepalive settings. The original specification vaguely said that these must be "set" by the SDKs. I took that out, but it is still vague. I would like to update it in a follow up with a specific recommendation. Based on another read of the gRPC docs, I think we should actually first leave it _off_ as it is by default, and only start to enable it after some testing. There is some risk of DDOS, with a lot of clients doing many pings, as these are not simple TCP pings handled at a network device, but application-level. So they are comparatively more expensive than normal TCP keepalive, as I understand it.