### PR TITLE
Update client library links to refer to the new sdks

### DIFF
--- a/src/content/docs/building-with-kessel/how-to/migrate-from-rbac-v1-to-v2.mdx
+++ b/src/content/docs/building-with-kessel/how-to/migrate-from-rbac-v1-to-v2.mdx
@@ -162,8 +162,10 @@ The implementation part typically consists of the following steps:
 Kessel client libraries are available for these languages:
 
 * [Java](https://github.com/project-kessel/inventory-client-java)
-* [golang](https://github.com/project-kessel/inventory-client-go)
-* [Python](https://github.com/project-kessel/inventory-client-python)
+* [golang](https://github.com/project-kessel/kessel-sdk-go)
+* [Python](https://github.com/project-kessel/kessel-sdk-py)
+* [Node] (https://github.com/project-kessel/kessel-sdk-node)
+
 
 <Aside type="note" title="Why gRPC and not REST?">
 In case you are wondering why the Kessel clients use gRPC to communicate with Kessel services instead of REST, take a look at [AUTHZ-005: gRPC vs. REST for platform RBAC Relation API calls](https://docs.google.com/document/d/1KkVii7dU-p86rkj5HA8RXcI4Y3WcMgcoaIFpcigWP3I/edit?tab=t.0)


### PR DESCRIPTION
- Update client library links in the migration guide to point to the latest sdks