### PR TITLE
Render client package spec element descriptions as markdown

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@astrojs/starlight-tailwind": "^4.0.1",
         "@tailwindcss/vite": "^4.0.7",
         "astro": "^5.12.5",
+        "marked": "^16.1.2",
         "sharp": "^0.32.5",
         "starlight-openapi": "^0.16.0",
         "tailwindcss": "^4.0.7",
@@ -4980,6 +4981,18 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/marked": {
+      "version": "16.1.2",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-16.1.2.tgz",
+      "integrity": "sha512-rNQt5EvRinalby7zJZu/mB+BvaAY2oz3wCuCjt1RDrWNpS1Pdf9xqMOeC9Hm5adBdcV/3XZPJpG58eT+WBc0XQ==",
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
     "node_modules/mdast-util-definitions": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/mdast-util-definitions/-/mdast-util-definitions-6.0.0.tgz",
@@ -6532,23 +6545,6 @@
       },
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/prettier": {
-      "version": "3.5.3",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.5.3.tgz",
-      "integrity": "sha512-QQtaxnoDJeAkDvDKWCLiwIXkTgRhwYDEQCghU9Z6q03iyek/rxRh/2lC3HB7P8sWT2xC/y5JDctPLBIGzHKbhw==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "bin": {
-        "prettier": "bin/prettier.cjs"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "node_modules/prismjs": {

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "@astrojs/starlight-tailwind": "^4.0.1",
     "@tailwindcss/vite": "^4.0.7",
     "astro": "^5.12.5",
+    "marked": "^16.1.2",
     "sharp": "^0.32.5",
     "starlight-openapi": "^0.16.0",
     "tailwindcss": "^4.0.7",

--- a/src/components/client-package/ClassItem.astro
+++ b/src/components/client-package/ClassItem.astro
@@ -2,6 +2,7 @@
 import ConstructorsList from "./ConstructorsList.astro";
 import PropertiesList from "./PropertiesList.astro";
 import MethodsList from "./MethodsList.astro";
+import MarkdownDescription from "./MarkdownDescription.astro";
 import type { Class } from "../../schemas/client-package";
 import type { MarkdownHeading } from "astro";
 
@@ -25,7 +26,7 @@ export function generateClassHeadings(classData: Class): MarkdownHeading[] {
 
 <section id={`class-${classData.name}`} class="mb-4">
   <h3>{classData.name}</h3>
-  {classData.description && <p>{classData.description}</p>}
+  <MarkdownDescription description={classData.description} />
 
   <ConstructorsList
     constructors={classData.constructors}

--- a/src/components/client-package/DescriptionBlock.astro
+++ b/src/components/client-package/DescriptionBlock.astro
@@ -1,5 +1,5 @@
 ---
-import MarkdownDescription from './MarkdownDescription.astro';
+import MarkdownDescription from "./MarkdownDescription.astro";
 
 interface Props {
   description?: string;

--- a/src/components/client-package/DescriptionBlock.astro
+++ b/src/components/client-package/DescriptionBlock.astro
@@ -1,4 +1,6 @@
 ---
+import MarkdownDescription from './MarkdownDescription.astro';
+
 interface Props {
   description?: string;
 }
@@ -6,10 +8,4 @@ interface Props {
 const { description } = Astro.props;
 ---
 
-{
-  description && (
-    <div class="mt-1 ml-4 text-sm text-gray-600 dark:text-gray-400">
-      {description}
-    </div>
-  )
-}
+<MarkdownDescription description={description} />

--- a/src/components/client-package/MarkdownDescription.astro
+++ b/src/components/client-package/MarkdownDescription.astro
@@ -1,0 +1,20 @@
+---
+import { marked } from "marked";
+
+interface Props {
+  description?: string;
+}
+
+const { description } = Astro.props;
+
+const htmlContent = description ? await marked.parse(description) : "";
+---
+
+{
+  description && (
+    <div
+      class="mt-1 ml-4 text-sm text-gray-600 dark:text-gray-400"
+      set:html={htmlContent}
+    />
+  )
+}


### PR DESCRIPTION
Markdown was creeping into them (newlines, code ticks), so this makes them render nicely for readability.