### PR TITLE
Update client library quickstart

### DIFF
--- a/src/content/docs/start-here/getting-started.mdx
+++ b/src/content/docs/start-here/getting-started.mdx
@@ -3,8 +3,15 @@ title: Getting Started with RBAC
 description: Step-by-step instructions for installing and running Kessel with your first managed and access controlled resource.
 ---
 
-import { Aside, Card, CardGrid, LinkButton, Steps, Tabs, TabItem } from '@astrojs/starlight/components';
+import { Aside, Card, CardGrid, LinkButton, Steps, Tabs, TabItem, Code } from '@astrojs/starlight/components';
 import SdkExamples from 'src/components/SdkExamples.astro';
+
+import commonRepresentation from 'src/examples/host/common_representation.json?raw';
+import hostConfig from 'src/examples/host/config.yaml?raw';
+import hbiConfig from 'src/examples/host/reporters/hbi/config.yaml?raw';
+import hbiHost from 'src/examples/host/reporters/hbi/host.json?raw';
+import resourceRelationshipsSchema from 'src/examples/resource_relationships_schema.ksl?raw';
+import rbacSchema from 'src/examples/rbac.ksl?raw';
 
 TODO: Tutorial to run through end to end basic usage of Kessel with very basic demo/toy code, using the client libraries.
 Use the Tabs component to show code examples with different tabs for language (e.g. python vs go).
@@ -27,62 +34,17 @@ Configure a basic resource that ties into RBAC for permissions. Following is an 
 <Steps>
 1. Author schemas
 
-    {/* 
-    NOTE: you can write files for these and then just import them.
+    <Code code={commonRepresentation} lang="json" title="host/common_representation.json" />
 
-    e.g.
+    <Code code={hostConfig} lang="yaml" title="host/config.yaml" />
 
-    import someRepresentation from 'src/examples/common_rep.json?raw'
+    <Code code={hbiConfig} lang="yaml" title="host/reporters/hbi/config.yaml" />
 
-    <Code code={someRepresentation> lang="json" title="host/common_representation.json"} />
-    */}
+    <Code code={hbiHost} lang="json" title="host/reporters/hbi/host.json" />
 
-    ```json title="host/common_representation.json"
-    {
-    "$schema": "http://json-schema.org/draft-07/schema#",
-    "type": "object",
-    "properties": {
-        "workspace_id": {
-            "type": "string"
-        }
-    },
-    "required": ["workspace_id"]
-   }    
-    ```
+    <Code code={resourceRelationshipsSchema} lang="ksl" title="resource_relationships_schema.ksl" />
 
-    ```yaml title="host/config.yaml"
-    resource_type: host
-    resource_reporters:
-      - hbi
-    ```
-
-    ```yaml title="host/reporters/hbi/config.yaml"
-    resource_type: host
-    reporter_name: hbi
-    namespace: hbi
-    ```
-
-    ```json title="host/reporters/hbi/host.json"
-    {
-    "$schema": "http://json-schema.org/draft-07/schema#",
-    "type": "object",
-    "properties": {
-        "insights_inventory_id": {
-            "type": "string",
-            "format": "uuid"
-        }
-    },
-    "required": []
-   }
-    ```
-
-    ```ksl title="path/to/resource_relationships_schema.ksl"
-    ksl for resource
-    ```
-
-    ```ksl title="path/to/rbac.ksl"
-    ksl for rbac
-    ```
+    <Code code={rbacSchema} lang="ksl" title="rbac.ksl" />
 2. Compile to SpiceDB schema
 
     ```bash

--- a/src/content/docs/start-here/getting-started.mdx
+++ b/src/content/docs/start-here/getting-started.mdx
@@ -149,9 +149,6 @@ Configure a basic resource that ties into RBAC for permissions. Following is an 
 
 ### Import a client
 
-TODO: This section will be updated shortly. 
-In the meantime, we will show you how to make calls using grpcurl
-
 <Tabs syncKey="language">
   <TabItem label="Python">
   ```bash

--- a/src/content/sdk-examples-check/curl.md
+++ b/src/content/sdk-examples-check/curl.md
@@ -3,4 +3,10 @@ language: "curl"
 order: 10
 ---
 
-TODO: Add curl example
+```bash
+MESSAGE='{"object": {"resourceType": "group", "resourceId": "bob_club", "reporter": {"type": "rbac"}}, "relation": "member", "subject": {"resource": {"resourceType": "principal", "resourceId": "bob", "reporter": {"type": "rbac"}}}}'
+curl -X POST \
+  -H "Content-Type: application/json" \
+  -d "$MESSAGE" \
+  http://localhost:<your local port for inventory>/api/inventory/v1beta2/check
+```

--- a/src/content/sdk-examples-check/go.md
+++ b/src/content/sdk-examples-check/go.md
@@ -22,6 +22,19 @@ import (
 func checkResource() {
 	ctx := context.Background()
 
+	// For authenticated environments, uncomment and configure the following:
+	// auth, err := oauth2.NewClientCredentials(oauth2.ClientCredentialsConfig{
+	//     ClientID:     clientID,
+	//     ClientSecret: clientSecret,
+	//     TokenURL:     issuerURL + "/token",
+	// })
+	// if err != nil {
+	//     log.Fatal("Failed to create OAuth2 credentials:", err)
+	// }
+	// inventoryClient, conn, err := v1beta2.NewClientBuilder(kesselEndpoint).
+	//     OAuth2ClientAuthenticated(auth).
+	//     Build()
+
 	inventoryClient, conn, err := v1beta2.NewClientBuilder(KESSEL_ENDPOINT).
 		Insecure().
 		Build()

--- a/src/content/sdk-examples-check/go.md
+++ b/src/content/sdk-examples-check/go.md
@@ -9,25 +9,23 @@ package main
 import (
 	"context"
 	"fmt"
-	"google.golang.org/protobuf/types/known/structpb"
 	"log"
 	"os"
 
 	_ "github.com/joho/godotenv/autoload"
 
-	v1beta2 "github.com/project-kessel/kessel-sdk-go/kessel/inventory/v1beta2"
+	"github.com/project-kessel/kessel-sdk-go/kessel/inventory/v1beta2"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/status"
 )
 
-func addr[T any](t T) *T { return &t }
-
 func main() {
 	ctx := context.Background()
 
 	var dialOpts []grpc.DialOption
+
 	dialOpts = append(dialOpts, grpc.WithTransportCredentials(insecure.NewCredentials()))
 
 	conn, err := grpc.NewClient(os.Getenv("KESSEL_ENDPOINT"), dialOpts...)
@@ -42,36 +40,27 @@ func main() {
 
 	inventoryClient := v1beta2.NewKesselInventoryServiceClient(conn)
 
-	reportResourceRequest := &v1beta2.ReportResourceRequest{
-		Type:               "host",
-		ReporterType:       "hbi",
-		ReporterInstanceId: "0a2a430e-1ad9-4304-8e75-cc6fd3b5441a",
-		Representations: &v1beta2.ResourceRepresentations{
-			Metadata: &v1beta2.RepresentationMetadata{
-				LocalResourceId: "854589f0-3be7-4cad-8bcd-45e18f33cb81",
-				ApiHref:         "https://apiHref.com/",
-				ConsoleHref:     addr("https://www.consoleHref.com/"),
-				ReporterVersion: addr("0.2.11"),
+	// Example request using the external API types
+	checkRequest := &v1beta2.CheckRequest{
+		Object: &v1beta2.ResourceReference{
+			ResourceType: "host",
+			ResourceId:   "1213",
+			Reporter: &v1beta2.ReporterReference{
+				Type: "HBI",
 			},
-			Common: &structpb.Struct{
-				Fields: map[string]*structpb.Value{
-					"workspace_id": structpb.NewStringValue("6eb10953-4ec9-4feb-838f-ba43a60880bf"),
-				},
-			},
-			Reporter: &structpb.Struct{
-				Fields: map[string]*structpb.Value{
-					"satellite_id":          structpb.NewStringValue("ca234d8f-9861-4659-a033-e80460b2801c"),
-					"sub_manager_id":        structpb.NewStringValue("e9b7d65f-3f81-4c26-b86c-2db663376eed"),
-					"insights_inventory_id": structpb.NewStringValue("c4b9b5e7-a82a-467a-b382-024a2f18c129"),
-					"ansible_host":          structpb.NewStringValue("host-1"),
-				},
+		},
+		Relation: "member",
+		Subject: &v1beta2.SubjectReference{
+			Resource: &v1beta2.ResourceReference{
+				ResourceType: "user",
+				ResourceId:   "tim",
 			},
 		},
 	}
 
-	fmt.Println("Making report resource request:")
+	fmt.Println("Making basic gRPC request:")
 
-	response, err := inventoryClient.ReportResource(ctx, reportResourceRequest)
+	response, err := inventoryClient.Check(ctx, checkRequest)
 	if err != nil {
 		if st, ok := status.FromError(err); ok {
 			switch st.Code() {
@@ -86,7 +75,6 @@ func main() {
 			log.Fatal("Unknown error: ", err)
 		}
 	}
-	fmt.Printf("Report resource response: %+v\n", response)
+	fmt.Printf("Check response: %+v\n", response)
 }
-
 ```

--- a/src/content/sdk-examples-check/go.md
+++ b/src/content/sdk-examples-check/go.md
@@ -15,20 +15,16 @@ import (
 	_ "github.com/joho/godotenv/autoload"
 
 	"github.com/project-kessel/kessel-sdk-go/kessel/inventory/v1beta2"
-	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/status"
 )
 
-func main() {
+func checkResource() {
 	ctx := context.Background()
 
-	var dialOpts []grpc.DialOption
-
-	dialOpts = append(dialOpts, grpc.WithTransportCredentials(insecure.NewCredentials()))
-
-	conn, err := grpc.NewClient(os.Getenv("KESSEL_ENDPOINT"), dialOpts...)
+	inventoryClient, conn, err := v1beta2.NewClientBuilder(KESSEL_ENDPOINT).
+		Insecure().
+		Build()
 	if err != nil {
 		log.Fatal("Failed to create gRPC client:", err)
 	}
@@ -38,28 +34,27 @@ func main() {
 		}
 	}()
 
-	inventoryClient := v1beta2.NewKesselInventoryServiceClient(conn)
-
-	// Example request using the external API types
 	checkRequest := &v1beta2.CheckRequest{
 		Object: &v1beta2.ResourceReference{
-			ResourceType: "host",
-			ResourceId:   "1213",
+			ResourceType: "group",
+			ResourceId:   "bob_club",
 			Reporter: &v1beta2.ReporterReference{
-				Type: "HBI",
+				Type: "rbac",
 			},
 		},
 		Relation: "member",
 		Subject: &v1beta2.SubjectReference{
 			Resource: &v1beta2.ResourceReference{
-				ResourceType: "user",
-				ResourceId:   "tim",
+				ResourceType: "principal",
+				ResourceId:   "bob",
+				Reporter: &v1beta2.ReporterReference{
+					Type: "rbac",
+				},
 			},
 		},
 	}
 
-	fmt.Println("Making basic gRPC request:")
-
+	fmt.Println("Making check request:")
 	response, err := inventoryClient.Check(ctx, checkRequest)
 	if err != nil {
 		if st, ok := status.FromError(err); ok {
@@ -77,4 +72,6 @@ func main() {
 	}
 	fmt.Printf("Check response: %+v\n", response)
 }
+
+func main() { checkResource() }
 ```

--- a/src/content/sdk-examples-check/grpcurl.md
+++ b/src/content/sdk-examples-check/grpcurl.md
@@ -4,7 +4,7 @@ order: 0
 ---
 
 ```bash
-MESSAGE='{"object": {"resourceType": "host", "resourceId": "dd1b73b9-3e33-4264-968c-e3ce55b9afec", "reporter": {"type": "hbi", "instanceId": "3088be62-1c60-4884-b133-9200542d0b3f"}}, "relation": "workspace", "subject": {"resource": {"resourceType": "workspace", "resourceId": "a64d17d0-aec3-410a-acd0-e0b85b22c076", "reporter": {"type": "rbac", "instanceId": "3088be62-1c60-4884-b133-9200542d0b3f"}}}}'
+MESSAGE='{"object": {"resourceType": "group", "resourceId": "bob_club", "reporter": {"type": "rbac"}}, "relation": "member", "subject": {"resource": {"resourceType": "principal", "resourceId": "bob", "reporter": {"type": "rbac"}}}}'
 grpcurl -plaintext -d $MESSAGE \
 localhost: <your local port for inventory> \
 kessel.inventory.v1beta2.KesselInventoryService.Check

--- a/src/content/sdk-examples-check/grpcurl.md
+++ b/src/content/sdk-examples-check/grpcurl.md
@@ -4,8 +4,8 @@ order: 0
 ---
 
 ```bash
-MESSAGE='{"type": "host", "reporterType": "hbi", "reporterInstanceId": "3088be62-1c60-4884-b133-9200542d0b3f","representations": {"metadata": {"localResourceId": "dd1b73b9-3e33-4264-968c-e3ce55b9afec","apiHref": "https://apiHref.com/","consoleHref": "https://www.console.com/","reporterVersion": "2.7.16"},"common": {"workspace_id": "a64d17d0-aec3-410a-acd0-e0b85b22c076"},"reporter": {"insights_inventory_id": "05707922-7b0a-4fe6-982d-6adbc7695b8f"}}}'
+MESSAGE='{"object": {"resourceType": "host", "resourceId": "dd1b73b9-3e33-4264-968c-e3ce55b9afec", "reporter": {"type": "hbi", "instanceId": "3088be62-1c60-4884-b133-9200542d0b3f"}}, "relation": "workspace", "subject": {"resource": {"resourceType": "workspace", "resourceId": "a64d17d0-aec3-410a-acd0-e0b85b22c076", "reporter": {"type": "rbac", "instanceId": "3088be62-1c60-4884-b133-9200542d0b3f"}}}}'
 grpcurl -plaintext -d $MESSAGE \
 localhost: <your local port for inventory> \
-kessel.inventory.v1beta2.KesselInventoryService.ReportResource
-  ```
+kessel.inventory.v1beta2.KesselInventoryService.Check
+```

--- a/src/content/sdk-examples-check/javascript.md
+++ b/src/content/sdk-examples-check/javascript.md
@@ -12,6 +12,15 @@ import "dotenv/config";
 
 async function run() {
   try {
+    // For authenticated environments, uncomment and configure the following:
+    // const auth = await OAuth2ClientCredentials.fromDiscovery({
+    //   clientId: CLIENT_ID,
+    //   clientSecret: CLIENT_SECRET,
+    //   issuerUrl: ISSUER_URL,
+    // });
+    // const client = new ClientBuilder(KESSEL_ENDPOINT).oauth2ClientAuthenticated(auth).buildAsync();
+
+    // For insecure local development:
     const client = new ClientBuilder(process.env.KESSEL_ENDPOINT).insecure().buildAsync();
 
     const subjectReference: SubjectReference = {

--- a/src/content/sdk-examples-check/javascript.md
+++ b/src/content/sdk-examples-check/javascript.md
@@ -4,59 +4,52 @@ order: 40
 ---
 
 ```javascript
-import { KesselInventoryServiceClient } from "@project-kessel/kessel-sdk/kessel/inventory/v1beta2/inventory_service";
-import { ReportResourceRequest } from "@project-kessel/kessel-sdk/kessel/inventory/v1beta2/report_resource_request";
-import { ResourceRepresentations } from "@project-kessel/kessel-sdk/kessel/inventory/v1beta2/resource_representations";
-import { RepresentationMetadata } from "@project-kessel/kessel-sdk/kessel/inventory/v1beta2/representation_metadata";
-import { ChannelCredentials } from "@grpc/grpc-js";
 import "dotenv/config";
+import { KesselInventoryServiceClient } from "@project-kessel/kessel-sdk/kessel/inventory/v1beta2/inventory_service";
+import { ResourceReference } from "@project-kessel/kessel-sdk/kessel/inventory/v1beta2/resource_reference";
+import { SubjectReference } from "@project-kessel/kessel-sdk/kessel/inventory/v1beta2/subject_reference";
+import { CheckRequest } from "@project-kessel/kessel-sdk/kessel/inventory/v1beta2/check_request";
+import { ChannelCredentials } from "@grpc/grpc-js";
 
 const stub = new KesselInventoryServiceClient(
-  process.env.KESSEL_ENDPOINT,
-  ChannelCredentials.createInsecure(),
-  {
-    // Channel options
-  },
+    process.env.KESSEL_ENDPOINT,
+    ChannelCredentials.createInsecure(),
+    {
+        // Channel options
+    },
 );
 
-const common = {
-  workspace_id: "6eb10953-4ec9-4feb-838f-ba43a60880bf",
+const subjectReference: SubjectReference = {
+    resource: {
+        reporter: {
+            type: "rbac",
+        },
+        resourceId: "foobar",
+        resourceType: "principal",
+    },
 };
 
-const reporter = {
-  satellite_id: "ca234d8f-9861-4659-a033-e80460b2801c",
-  sub_manager_id: "e9b7d65f-3f81-4c26-b86c-2db663376eed",
-  insights_inventory_id: "c4b9b5e7-a82a-467a-b382-024a2f18c129",
-  ansible_host: "host-1",
+const resource: ResourceReference = {
+    reporter: {
+        type: "rbac",
+    },
+    resourceId: "1234",
+    resourceType: "workspace",
 };
 
-const metadata: RepresentationMetadata = {
-  localResourceId: "854589f0-3be7-4cad-8bcd-45e18f33cb81",
-  apiHref: "https://apiHref.com/",
-  consoleHref: "https://www.consoleHref.com/",
-  reporterVersion: "0.2.11",
+const check_request: CheckRequest = {
+    object: resource,
+    relation: "inventory_host_view",
+    subject: subjectReference,
 };
 
-const representations: ResourceRepresentations = {
-  metadata: metadata,
-  common: common,
-  reporter: reporter,
-};
-
-const reportResourceRequest: ReportResourceRequest = {
-  type: "host",
-  reporterType: "hbi",
-  reporterInstanceId: "0a2a430e-1ad9-4304-8e75-cc6fd3b5441a",
-  representations,
-};
-
-stub.reportResource(reportResourceRequest, (error, response) => {
-  if (!error) {
-    console.log("Resource reported successfully:");
-    console.log(response);
-  } else {
-    console.log("gRPC error occurred during Resource reporting:");
-    console.log(`Exception:`, error);
-  }
+stub.check(check_request, (error, response) => {
+    if (!error) {
+        console.log("Check response received successfully:");
+        console.log(response);
+    } else {
+        console.log("gRPC error occurred during Check:");
+        console.log(`Exception:`, error);
+    }
 });
 ```

--- a/src/content/sdk-examples-check/javascript.md
+++ b/src/content/sdk-examples-check/javascript.md
@@ -4,52 +4,49 @@ order: 40
 ---
 
 ```javascript
-import "dotenv/config";
-import { KesselInventoryServiceClient } from "@project-kessel/kessel-sdk/kessel/inventory/v1beta2/inventory_service";
 import { ResourceReference } from "@project-kessel/kessel-sdk/kessel/inventory/v1beta2/resource_reference";
 import { SubjectReference } from "@project-kessel/kessel-sdk/kessel/inventory/v1beta2/subject_reference";
 import { CheckRequest } from "@project-kessel/kessel-sdk/kessel/inventory/v1beta2/check_request";
-import { ChannelCredentials } from "@grpc/grpc-js";
+import { ClientBuilder } from "@project-kessel/kessel-sdk/kessel/inventory/v1beta2";
+import "dotenv/config";
 
-const stub = new KesselInventoryServiceClient(
-    process.env.KESSEL_ENDPOINT,
-    ChannelCredentials.createInsecure(),
-    {
-        // Channel options
-    },
-);
+async function run() {
+  try {
+    const client = new ClientBuilder(process.env.KESSEL_ENDPOINT).insecure().buildAsync();
 
-const subjectReference: SubjectReference = {
-    resource: {
+    const subjectReference: SubjectReference = {
+        resource: {
+            reporter: {
+                type: "rbac",
+            },
+            resourceId: "bob",
+            resourceType: "principal",
+        },
+    };
+
+    const resource: ResourceReference = {
         reporter: {
             type: "rbac",
         },
-        resourceId: "foobar",
-        resourceType: "principal",
-    },
-};
+        resourceId: "bob_club",
+        resourceType: "group",
+    };
 
-const resource: ResourceReference = {
-    reporter: {
-        type: "rbac",
-    },
-    resourceId: "1234",
-    resourceType: "workspace",
-};
+    const check_request: CheckRequest = {
+        object: resource,
+        relation: "member",
+        subject: subjectReference,
+    };
 
-const check_request: CheckRequest = {
-    object: resource,
-    relation: "inventory_host_view",
-    subject: subjectReference,
-};
+    const response = await client.check(check_request);
+    console.log("Check response received successfully:");
+    console.log(response);
 
-stub.check(check_request, (error, response) => {
-    if (!error) {
-        console.log("Check response received successfully:");
-        console.log(response);
-    } else {
-        console.log("gRPC error occurred during Check:");
-        console.log(`Exception:`, error);
-    }
-});
+  } catch (error) {
+    console.log("gRPC error occurred during Check:");
+    console.log("Exception:", error);
+  }
+}
+
+run();
 ```

--- a/src/content/sdk-examples-check/python.md
+++ b/src/content/sdk-examples-check/python.md
@@ -5,51 +5,51 @@ order: 20
 
 ```python
 import grpc
+import os
 
 from kessel.inventory.v1beta2 import (
-    inventory_service_pb2_grpc,
     check_request_pb2,
     resource_reference_pb2,
     reporter_reference_pb2,
     subject_reference_pb2,
+    ClientBuilder,
 )
 
 
 def run():
-    stub = inventory_service_pb2_grpc.KesselInventoryServiceStub(
-        grpc.insecure_channel("localhost:9000")
-    )
+    stub, channel = ClientBuilder(KESSEL_ENDPOINT).insecure().build()
 
-    # Prepare the subject reference object
-    subject = subject_reference_pb2.SubjectReference(
-        resource=resource_reference_pb2.ResourceReference(
-            reporter=reporter_reference_pb2.ReporterReference(type="rbac"),
-            resource_id="bob",
-            resource_type="principal",
+    with channel:
+        # Prepare the subject reference object
+        subject = subject_reference_pb2.SubjectReference(
+            resource=resource_reference_pb2.ResourceReference(
+                reporter=reporter_reference_pb2.ReporterReference(type="rbac"),
+                resource_id="bob",
+                resource_type="principal",
+            )
         )
-    )
 
-    # Prepare the resource reference object
-    resource_ref = resource_reference_pb2.ResourceReference(
-        resource_id="bob_club",
-        resource_type="group",
-        reporter=reporter_reference_pb2.ReporterReference(type="rbac"),
-    )
+        # Prepare the resource reference object
+        resource_ref = resource_reference_pb2.ResourceReference(
+            resource_id="bob_club",
+            resource_type="group",
+            reporter=reporter_reference_pb2.ReporterReference(type="rbac"),
+        )
 
-    check_request = check_request_pb2.CheckRequest(
-        subject=subject,
-        relation="member",
-        object=resource_ref,
-    )
+        check_request = check_request_pb2.CheckRequest(
+            subject=subject,
+            relation="member",
+            object=resource_ref,
+        )
 
-    try:
-        check_response = stub.Check(check_request)
-        print("Check response received successfully")
-        print(check_response)
-    except grpc.RpcError as e:
-        print("gRPC error occurred during Check:")
-        print(f"Code: {e.code()}")
-        print(f"Details: {e.details()}")
+        try:
+            check_response = stub.Check(check_request)
+            print("Check response received successfully")
+            print(check_response)
+        except grpc.RpcError as e:
+            print("gRPC error occurred during Check:")
+            print(f"Code: {e.code()}")
+            print(f"Details: {e.details()}")
 
 
 if __name__ == "__main__":

--- a/src/content/sdk-examples-check/python.md
+++ b/src/content/sdk-examples-check/python.md
@@ -17,6 +17,16 @@ from kessel.inventory.v1beta2 import (
 
 
 def run():
+    # For authenticated environments, uncomment and configure the following:
+    # discovery = fetch_oidc_discovery(ISSUER_URL)
+    # auth_credentials = OAuth2ClientCredentials(
+    #     client_id=CLIENT_ID,
+    #     client_secret=CLIENT_SECRET,
+    #     token_endpoint=discovery.token_endpoint,
+    # )
+    # stub, channel = ClientBuilder(KESSEL_ENDPOINT).oauth2_client_authenticated(auth_credentials).build()
+
+    # For insecure local development:
     stub, channel = ClientBuilder(KESSEL_ENDPOINT).insecure().build()
 
     with channel:

--- a/src/content/sdk-examples-check/ruby.md
+++ b/src/content/sdk-examples-check/ruby.md
@@ -12,14 +12,16 @@ require 'kessel-sdk'
 
 include Kessel::Inventory::V1beta2
 
-client = KesselInventoryService::Stub.new(ENV.fetch('KESSEL_ENDPOINT', nil), :this_channel_is_insecure)
+client = KesselInventoryService::ClientBuilder.new(ENV.fetch('KESSEL_ENDPOINT', 'nil'))
+                                              .insecure
+                                              .build
 
 subject_reference = SubjectReference.new(
   resource: ResourceReference.new(
     reporter: ReporterReference.new(
       type: 'rbac'
     ),
-    resource_id: 'foobar',
+    resource_id: 'bob',
     resource_type: 'principal'
   )
 )
@@ -28,22 +30,22 @@ resource = ResourceReference.new(
   reporter: ReporterReference.new(
     type: 'rbac'
   ),
-  resource_id: '1234',
-  resource_type: 'workspace'
+  resource_id: 'bob_club',
+  resource_type: 'group'
 )
 
 begin
   response = client.check(
     CheckRequest.new(
       object: resource,
-      relation: 'inventory_host_view',
+      relation: 'member',
       subject: subject_reference
     )
   )
   p 'check response received successfully:'
   p response
-rescue Exception => e
+rescue => e
   p 'gRPC error occurred during check:'
-  p "Exception #{e}"
+  p "Exception: #{e}"
 end
 ```

--- a/src/content/sdk-examples-check/ruby.md
+++ b/src/content/sdk-examples-check/ruby.md
@@ -12,6 +12,17 @@ require 'kessel-sdk'
 
 include Kessel::Inventory::V1beta2
 
+# For authenticated environments, uncomment and configure the following:
+# auth_credentials = OAuth2ClientCredentials.new(
+#   client_id: CLIENT_ID,
+#   client_secret: CLIENT_SECRET,
+#   token_endpoint: "#{ISSUER_URL}/token"
+# )
+# client = KesselInventoryService::ClientBuilder.new(KESSEL_ENDPOINT)
+#                                               .oauth2_client_authenticated(auth_credentials)
+#                                               .build
+
+# For insecure local development:
 client = KesselInventoryService::ClientBuilder.new(ENV.fetch('KESSEL_ENDPOINT', 'nil'))
                                               .insecure
                                               .build

--- a/src/content/sdk-examples-check/ruby.md
+++ b/src/content/sdk-examples-check/ruby.md
@@ -8,48 +8,42 @@ order: 50
 # frozen_string_literal: true
 
 require 'dotenv/load'
-require 'json'
 require 'kessel-sdk'
 
 include Kessel::Inventory::V1beta2
 
 client = KesselInventoryService::Stub.new(ENV.fetch('KESSEL_ENDPOINT', nil), :this_channel_is_insecure)
 
-common = Google::Protobuf::Struct.decode_json({ 'workspace_id' => '6eb10953-4ec9-4feb-838f-ba43a60880bf' }.to_json)
-
-reporter = Google::Protobuf::Struct.decode_json({
-  'satellite_id' => 'ca234d8f-9861-4659-a033-e80460b2801c',
-  'sub_manager_id' => 'e9b7d65f-3f81-4c26-b86c-2db663376eed',
-  'insights_inventory_id' => 'c4b9b5e7-a82a-467a-b382-024a2f18c129',
-  'ansible_host' => 'host-1'
-}.to_json)
-
-metadata = RepresentationMetadata.new(
-  local_resource_id: '854589f0-3be7-4cad-8bcd-45e18f33cb81',
-  api_href: 'https://apiHref.com/',
-  console_href: 'https://www.consoleHref.com/',
-  reporter_version: '0.2.11'
+subject_reference = SubjectReference.new(
+  resource: ResourceReference.new(
+    reporter: ReporterReference.new(
+      type: 'rbac'
+    ),
+    resource_id: 'foobar',
+    resource_type: 'principal'
+  )
 )
 
-representations = ResourceRepresentations.new(
-  metadata: metadata,
-  common: common,
-  reporter: reporter
+resource = ResourceReference.new(
+  reporter: ReporterReference.new(
+    type: 'rbac'
+  ),
+  resource_id: '1234',
+  resource_type: 'workspace'
 )
 
 begin
-  response = client.report_resource(
-    ReportResourceRequest.new(
-      type: 'host',
-      reporter_type: 'hbi',
-      reporter_instance_id: '0a2a430e-1ad9-4304-8e75-cc6fd3b5441a',
-      representations: representations
+  response = client.check(
+    CheckRequest.new(
+      object: resource,
+      relation: 'inventory_host_view',
+      subject: subject_reference
     )
   )
-  p 'report_resource response received successfully:'
+  p 'check response received successfully:'
   p response
 rescue Exception => e
-  p 'gRPC error occurred during report_resource:'
+  p 'gRPC error occurred during check:'
   p "Exception #{e}"
 end
 ```

--- a/src/content/sdk-examples-report-resources/curl.md
+++ b/src/content/sdk-examples-report-resources/curl.md
@@ -3,4 +3,10 @@ language: "curl"
 order: 10
 ---
 
-TODO: Add curl example
+```bash
+MESSAGE='{"type": "host", "reporterType": "hbi", "reporterInstanceId": "3088be62-1c60-4884-b133-9200542d0b3f","representations": {"metadata": {"localResourceId": "dd1b73b9-3e33-4264-968c-e3ce55b9afec","apiHref": "https://apiHref.com/","consoleHref": "https://www.console.com/","reporterVersion": "2.7.16"},"common": {"workspace_id": "a64d17d0-aec3-410a-acd0-e0b85b22c076"},"reporter": {"insights_inventory_id": "05707922-7b0a-4fe6-982d-6adbc7695b8f"}}}'
+curl -X POST \
+  -H "Content-Type: application/json" \
+  -d "$MESSAGE" \
+  http://localhost:<your local port for inventory>/api/inventory/v1beta2/resources
+```

--- a/src/content/sdk-examples-report-resources/go.md
+++ b/src/content/sdk-examples-report-resources/go.md
@@ -9,28 +9,38 @@ package main
 import (
 	"context"
 	"fmt"
-	"google.golang.org/protobuf/types/known/structpb"
 	"log"
 	"os"
 
+	"google.golang.org/protobuf/types/known/structpb"
+
 	_ "github.com/joho/godotenv/autoload"
 
-	v1beta2 "github.com/project-kessel/kessel-sdk-go/kessel/inventory/v1beta2"
-	"google.golang.org/grpc"
+	"github.com/project-kessel/kessel-sdk-go/kessel/inventory/v1beta2"
 	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/status"
 )
 
-func addr[T any](t T) *T { return &t }
-
-func main() {
+func reportResource() {
 	ctx := context.Background()
 
-	var dialOpts []grpc.DialOption
-	dialOpts = append(dialOpts, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	// For authenticated environments, uncomment and configure the following:
+	// auth, err := oauth2.NewClientCredentials(oauth2.ClientCredentialsConfig{
+	//     ClientID:     clientID,
+	//     ClientSecret: clientSecret,
+	//     TokenURL:     issuerURL + "/token",
+	// })
+	// if err != nil {
+	//     log.Fatal("Failed to create OAuth2 credentials:", err)
+	// }
+	// inventoryClient, conn, err := v1beta2.NewClientBuilder(kesselEndpoint).
+	//     OAuth2ClientAuthenticated(auth).
+	//     Build()
 
-	conn, err := grpc.NewClient(os.Getenv("KESSEL_ENDPOINT"), dialOpts...)
+	// For insecure local development:
+	inventoryClient, conn, err := v1beta2.NewClientBuilder(kesselEndpoint).
+		Insecure().
+		Build()
 	if err != nil {
 		log.Fatal("Failed to create gRPC client:", err)
 	}
@@ -40,29 +50,27 @@ func main() {
 		}
 	}()
 
-	inventoryClient := v1beta2.NewKesselInventoryServiceClient(conn)
-
 	reportResourceRequest := &v1beta2.ReportResourceRequest{
 		Type:               "host",
 		ReporterType:       "hbi",
-		ReporterInstanceId: "0a2a430e-1ad9-4304-8e75-cc6fd3b5441a",
+		ReporterInstanceId: "3088be62-1c60-4884-b133-9200542d0b3f",
 		Representations: &v1beta2.ResourceRepresentations{
 			Metadata: &v1beta2.RepresentationMetadata{
-				LocalResourceId: "854589f0-3be7-4cad-8bcd-45e18f33cb81",
+				LocalResourceId: "dd1b73b9-3e33-4264-968c-e3ce55b9afec",
 				ApiHref:         "https://apiHref.com/",
-				ConsoleHref:     addr("https://www.consoleHref.com/"),
-				ReporterVersion: addr("0.2.11"),
+				ConsoleHref:     addr("https://www.console.com/"),
+				ReporterVersion: addr("2.7.16"),
 			},
 			Common: &structpb.Struct{
 				Fields: map[string]*structpb.Value{
-					"workspace_id": structpb.NewStringValue("6eb10953-4ec9-4feb-838f-ba43a60880bf"),
+					"workspace_id": structpb.NewStringValue("a64d17d0-aec3-410a-acd0-e0b85b22c076"),
 				},
 			},
 			Reporter: &structpb.Struct{
 				Fields: map[string]*structpb.Value{
 					"satellite_id":          structpb.NewStringValue("ca234d8f-9861-4659-a033-e80460b2801c"),
 					"sub_manager_id":        structpb.NewStringValue("e9b7d65f-3f81-4c26-b86c-2db663376eed"),
-					"insights_inventory_id": structpb.NewStringValue("c4b9b5e7-a82a-467a-b382-024a2f18c129"),
+					"insights_inventory_id": structpb.NewStringValue("05707922-7b0a-4fe6-982d-6adbc7695b8f"),
 					"ansible_host":          structpb.NewStringValue("host-1"),
 				},
 			},
@@ -89,4 +97,7 @@ func main() {
 	fmt.Printf("Report resource response: %+v\n", response)
 }
 
+func addr[T any](t T) *T { return &t }
+
+func main() { reportResource() }
 ```

--- a/src/content/sdk-examples-report-resources/go.md
+++ b/src/content/sdk-examples-report-resources/go.md
@@ -9,23 +9,25 @@ package main
 import (
 	"context"
 	"fmt"
+	"google.golang.org/protobuf/types/known/structpb"
 	"log"
 	"os"
 
 	_ "github.com/joho/godotenv/autoload"
 
-	"github.com/project-kessel/kessel-sdk-go/kessel/inventory/v1beta2"
+	v1beta2 "github.com/project-kessel/kessel-sdk-go/kessel/inventory/v1beta2"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/status"
 )
 
+func addr[T any](t T) *T { return &t }
+
 func main() {
 	ctx := context.Background()
 
 	var dialOpts []grpc.DialOption
-
 	dialOpts = append(dialOpts, grpc.WithTransportCredentials(insecure.NewCredentials()))
 
 	conn, err := grpc.NewClient(os.Getenv("KESSEL_ENDPOINT"), dialOpts...)
@@ -40,27 +42,36 @@ func main() {
 
 	inventoryClient := v1beta2.NewKesselInventoryServiceClient(conn)
 
-	// Example request using the external API types
-	checkRequest := &v1beta2.CheckRequest{
-		Object: &v1beta2.ResourceReference{
-			ResourceType: "host",
-			ResourceId:   "1213",
-			Reporter: &v1beta2.ReporterReference{
-				Type: "HBI",
+	reportResourceRequest := &v1beta2.ReportResourceRequest{
+		Type:               "host",
+		ReporterType:       "hbi",
+		ReporterInstanceId: "0a2a430e-1ad9-4304-8e75-cc6fd3b5441a",
+		Representations: &v1beta2.ResourceRepresentations{
+			Metadata: &v1beta2.RepresentationMetadata{
+				LocalResourceId: "854589f0-3be7-4cad-8bcd-45e18f33cb81",
+				ApiHref:         "https://apiHref.com/",
+				ConsoleHref:     addr("https://www.consoleHref.com/"),
+				ReporterVersion: addr("0.2.11"),
 			},
-		},
-		Relation: "member",
-		Subject: &v1beta2.SubjectReference{
-			Resource: &v1beta2.ResourceReference{
-				ResourceType: "user",
-				ResourceId:   "tim",
+			Common: &structpb.Struct{
+				Fields: map[string]*structpb.Value{
+					"workspace_id": structpb.NewStringValue("6eb10953-4ec9-4feb-838f-ba43a60880bf"),
+				},
+			},
+			Reporter: &structpb.Struct{
+				Fields: map[string]*structpb.Value{
+					"satellite_id":          structpb.NewStringValue("ca234d8f-9861-4659-a033-e80460b2801c"),
+					"sub_manager_id":        structpb.NewStringValue("e9b7d65f-3f81-4c26-b86c-2db663376eed"),
+					"insights_inventory_id": structpb.NewStringValue("c4b9b5e7-a82a-467a-b382-024a2f18c129"),
+					"ansible_host":          structpb.NewStringValue("host-1"),
+				},
 			},
 		},
 	}
 
-	fmt.Println("Making basic gRPC request:")
+	fmt.Println("Making report resource request:")
 
-	response, err := inventoryClient.Check(ctx, checkRequest)
+	response, err := inventoryClient.ReportResource(ctx, reportResourceRequest)
 	if err != nil {
 		if st, ok := status.FromError(err); ok {
 			switch st.Code() {
@@ -75,6 +86,7 @@ func main() {
 			log.Fatal("Unknown error: ", err)
 		}
 	}
-	fmt.Printf("Check response: %+v\n", response)
+	fmt.Printf("Report resource response: %+v\n", response)
 }
+
 ```

--- a/src/content/sdk-examples-report-resources/grpcurl.md
+++ b/src/content/sdk-examples-report-resources/grpcurl.md
@@ -4,8 +4,8 @@ order: 0
 ---
 
 ```bash
-MESSAGE='{"object": {"resourceType": "host", "resourceId": "dd1b73b9-3e33-4264-968c-e3ce55b9afec", "reporter": {"type": "hbi", "instanceId": "3088be62-1c60-4884-b133-9200542d0b3f"}}, "relation": "workspace", "subject": {"resource": {"resourceType": "workspace", "resourceId": "a64d17d0-aec3-410a-acd0-e0b85b22c076", "reporter": {"type": "rbac", "instanceId": "3088be62-1c60-4884-b133-9200542d0b3f"}}}}'
+MESSAGE='{"type": "host", "reporterType": "hbi", "reporterInstanceId": "3088be62-1c60-4884-b133-9200542d0b3f","representations": {"metadata": {"localResourceId": "dd1b73b9-3e33-4264-968c-e3ce55b9afec","apiHref": "https://apiHref.com/","consoleHref": "https://www.console.com/","reporterVersion": "2.7.16"},"common": {"workspace_id": "a64d17d0-aec3-410a-acd0-e0b85b22c076"},"reporter": {"insights_inventory_id": "05707922-7b0a-4fe6-982d-6adbc7695b8f"}}}'
 grpcurl -plaintext -d $MESSAGE \
 localhost: <your local port for inventory> \
-kessel.inventory.v1beta2.KesselInventoryService.Check
-```
+kessel.inventory.v1beta2.KesselInventoryService.ReportResource
+  ```

--- a/src/content/sdk-examples-report-resources/javascript.md
+++ b/src/content/sdk-examples-report-resources/javascript.md
@@ -4,59 +4,65 @@ order: 40
 ---
 
 ```javascript
-import { KesselInventoryServiceClient } from "@project-kessel/kessel-sdk/kessel/inventory/v1beta2/inventory_service";
 import { ReportResourceRequest } from "@project-kessel/kessel-sdk/kessel/inventory/v1beta2/report_resource_request";
 import { ResourceRepresentations } from "@project-kessel/kessel-sdk/kessel/inventory/v1beta2/resource_representations";
 import { RepresentationMetadata } from "@project-kessel/kessel-sdk/kessel/inventory/v1beta2/representation_metadata";
-import { ChannelCredentials } from "@grpc/grpc-js";
+import { ClientBuilder } from "@project-kessel/kessel-sdk/kessel/inventory/v1beta2";
 import "dotenv/config";
 
-const stub = new KesselInventoryServiceClient(
-  process.env.KESSEL_ENDPOINT,
-  ChannelCredentials.createInsecure(),
-  {
-    // Channel options
-  },
-);
+async function run() {
+  try {
+    // For authenticated environments, uncomment and configure the following:
+    // const auth = await OAuth2ClientCredentials.fromDiscovery({
+    //   clientId: CLIENT_ID,
+    //   clientSecret: CLIENT_SECRET,
+    //   issuerUrl: ISSUER_URL,
+    // });
+    // const client = new ClientBuilder(KESSEL_ENDPOINT).oauth2ClientAuthenticated(auth).buildAsync();
 
-const common = {
-  workspace_id: "6eb10953-4ec9-4feb-838f-ba43a60880bf",
-};
+    // For insecure local development:
+    const client = new ClientBuilder(KESSEL_ENDPOINT).insecure().buildAsync();
 
-const reporter = {
-  satellite_id: "ca234d8f-9861-4659-a033-e80460b2801c",
-  sub_manager_id: "e9b7d65f-3f81-4c26-b86c-2db663376eed",
-  insights_inventory_id: "c4b9b5e7-a82a-467a-b382-024a2f18c129",
-  ansible_host: "host-1",
-};
+    const common = {
+      workspace_id: "a64d17d0-aec3-410a-acd0-e0b85b22c076",
+    };
 
-const metadata: RepresentationMetadata = {
-  localResourceId: "854589f0-3be7-4cad-8bcd-45e18f33cb81",
-  apiHref: "https://apiHref.com/",
-  consoleHref: "https://www.consoleHref.com/",
-  reporterVersion: "0.2.11",
-};
+    const reporter = {
+      satellite_id: "ca234d8f-9861-4659-a033-e80460b2801c",
+      sub_manager_id: "e9b7d65f-3f81-4c26-b86c-2db663376eed",
+      insights_inventory_id: "05707922-7b0a-4fe6-982d-6adbc7695b8f",
+      ansible_host: "host-1",
+    };
 
-const representations: ResourceRepresentations = {
-  metadata: metadata,
-  common: common,
-  reporter: reporter,
-};
+    const metadata: RepresentationMetadata = {
+      localResourceId: "dd1b73b9-3e33-4264-968c-e3ce55b9afec",
+      apiHref: "https://apiHref.com/",
+      consoleHref: "https://www.console.com/",
+      reporterVersion: "2.7.16",
+    };
 
-const reportResourceRequest: ReportResourceRequest = {
-  type: "host",
-  reporterType: "hbi",
-  reporterInstanceId: "0a2a430e-1ad9-4304-8e75-cc6fd3b5441a",
-  representations,
-};
+    const representations: ResourceRepresentations = {
+      metadata: metadata,
+      common: common,
+      reporter: reporter,
+    };
 
-stub.reportResource(reportResourceRequest, (error, response) => {
-  if (!error) {
+    const reportResourceRequest: ReportResourceRequest = {
+      type: "host",
+      reporterType: "hbi",
+      reporterInstanceId: "3088be62-1c60-4884-b133-9200542d0b3f",
+      representations,
+    };
+
+    const response = await client.reportResource(reportResourceRequest);
     console.log("Resource reported successfully:");
     console.log(response);
-  } else {
+
+  } catch (error) {
     console.log("gRPC error occurred during Resource reporting:");
-    console.log(`Exception:`, error);
+    console.log("Exception:", error);
   }
-});
+}
+
+run();
 ```

--- a/src/content/sdk-examples-report-resources/javascript.md
+++ b/src/content/sdk-examples-report-resources/javascript.md
@@ -4,52 +4,59 @@ order: 40
 ---
 
 ```javascript
-import "dotenv/config";
 import { KesselInventoryServiceClient } from "@project-kessel/kessel-sdk/kessel/inventory/v1beta2/inventory_service";
-import { ResourceReference } from "@project-kessel/kessel-sdk/kessel/inventory/v1beta2/resource_reference";
-import { SubjectReference } from "@project-kessel/kessel-sdk/kessel/inventory/v1beta2/subject_reference";
-import { CheckRequest } from "@project-kessel/kessel-sdk/kessel/inventory/v1beta2/check_request";
+import { ReportResourceRequest } from "@project-kessel/kessel-sdk/kessel/inventory/v1beta2/report_resource_request";
+import { ResourceRepresentations } from "@project-kessel/kessel-sdk/kessel/inventory/v1beta2/resource_representations";
+import { RepresentationMetadata } from "@project-kessel/kessel-sdk/kessel/inventory/v1beta2/representation_metadata";
 import { ChannelCredentials } from "@grpc/grpc-js";
+import "dotenv/config";
 
 const stub = new KesselInventoryServiceClient(
-    process.env.KESSEL_ENDPOINT,
-    ChannelCredentials.createInsecure(),
-    {
-        // Channel options
-    },
+  process.env.KESSEL_ENDPOINT,
+  ChannelCredentials.createInsecure(),
+  {
+    // Channel options
+  },
 );
 
-const subjectReference: SubjectReference = {
-    resource: {
-        reporter: {
-            type: "rbac",
-        },
-        resourceId: "foobar",
-        resourceType: "principal",
-    },
+const common = {
+  workspace_id: "6eb10953-4ec9-4feb-838f-ba43a60880bf",
 };
 
-const resource: ResourceReference = {
-    reporter: {
-        type: "rbac",
-    },
-    resourceId: "1234",
-    resourceType: "workspace",
+const reporter = {
+  satellite_id: "ca234d8f-9861-4659-a033-e80460b2801c",
+  sub_manager_id: "e9b7d65f-3f81-4c26-b86c-2db663376eed",
+  insights_inventory_id: "c4b9b5e7-a82a-467a-b382-024a2f18c129",
+  ansible_host: "host-1",
 };
 
-const check_request: CheckRequest = {
-    object: resource,
-    relation: "inventory_host_view",
-    subject: subjectReference,
+const metadata: RepresentationMetadata = {
+  localResourceId: "854589f0-3be7-4cad-8bcd-45e18f33cb81",
+  apiHref: "https://apiHref.com/",
+  consoleHref: "https://www.consoleHref.com/",
+  reporterVersion: "0.2.11",
 };
 
-stub.check(check_request, (error, response) => {
-    if (!error) {
-        console.log("Check response received successfully:");
-        console.log(response);
-    } else {
-        console.log("gRPC error occurred during Check:");
-        console.log(`Exception:`, error);
-    }
+const representations: ResourceRepresentations = {
+  metadata: metadata,
+  common: common,
+  reporter: reporter,
+};
+
+const reportResourceRequest: ReportResourceRequest = {
+  type: "host",
+  reporterType: "hbi",
+  reporterInstanceId: "0a2a430e-1ad9-4304-8e75-cc6fd3b5441a",
+  representations,
+};
+
+stub.reportResource(reportResourceRequest, (error, response) => {
+  if (!error) {
+    console.log("Resource reported successfully:");
+    console.log(response);
+  } else {
+    console.log("gRPC error occurred during Resource reporting:");
+    console.log(`Exception:`, error);
+  }
 });
 ```

--- a/src/content/sdk-examples-report-resources/python.md
+++ b/src/content/sdk-examples-report-resources/python.md
@@ -4,58 +4,77 @@ order: 20
 ---
 
 ```python
+import os
 import grpc
 from google.protobuf import struct_pb2
+from kessel.auth import fetch_oidc_discovery, OAuth2ClientCredentials
 from kessel.inventory.v1beta2 import (
-    inventory_service_pb2_grpc,
+    ClientBuilder,
     report_resource_request_pb2,
     resource_representations_pb2,
     representation_metadata_pb2,
 )
 
-stub = inventory_service_pb2_grpc.KesselInventoryServiceStub(
-    grpc.insecure_channel("localhost:9000")
-)
+def run():
+    try:
+        # For authenticated environments, uncomment and configure the following:
+        # discovery = fetch_oidc_discovery(ISSUER_URL)
+        # auth_credentials = OAuth2ClientCredentials(
+        #     client_id=CLIENT_ID,
+        #     client_secret=CLIENT_SECRET,
+        #     token_endpoint=discovery.token_endpoint,
+        # )
+        # stub, channel = ClientBuilder(KESSEL_ENDPOINT).oauth2_client_authenticated(auth_credentials).build()
 
-# Build protobuf Struct for common metadata
-common_struct = struct_pb2.Struct()
-common_struct.update({"workspace_id": "6eb10953-4ec9-4feb-838f-ba43a60880bf"})
+        # For insecure local development:
+        stub, channel = ClientBuilder(KESSEL_ENDPOINT).insecure().build()
 
-# Build protobuf Struct for reporter-specific data
-reporter_struct = struct_pb2.Struct()
-reporter_struct.update(
-    {
-        "satellite_id": "ca234d8f-9861-4659-a033-e80460b2801c",
-        "sub_manager_id": "e9b7d65f-3f81-4c26-b86c-2db663376eed",
-        "insights_inventory_id": "c4b9b5e7-a82a-467a-b382-024a2f18c129",
-        "ansible_host": "host-1",
-    }
-)
+        with channel:
+            # Build protobuf Struct for common metadata
+            common_struct = struct_pb2.Struct()
+            common_struct.update({"workspace_id": "a64d17d0-aec3-410a-acd0-e0b85b22c076"})
 
-# Create metadata for the resource representation
-metadata = representation_metadata_pb2.RepresentationMetadata(
-    local_resource_id="854589f0-3be7-4cad-8bcd-45e18f33cb81",
-    api_href="https://apiHref.com/",
-    console_href="https://www.consoleHref.com/",
-    reporter_version="0.2.11",
-)
+            # Build protobuf Struct for reporter-specific data
+            reporter_struct = struct_pb2.Struct()
+            reporter_struct.update(
+                {
+                    "satellite_id": "ca234d8f-9861-4659-a033-e80460b2801c",
+                    "sub_manager_id": "e9b7d65f-3f81-4c26-b86c-2db663376eed",
+                    "insights_inventory_id": "05707922-7b0a-4fe6-982d-6adbc7695b8f",
+                    "ansible_host": "host-1",
+                }
+            )
 
-# Build the resource representations
-representations = resource_representations_pb2.ResourceRepresentations(
-    metadata=metadata, common=common_struct, reporter=reporter_struct
-)
+            # Create metadata for the resource representation
+            metadata = representation_metadata_pb2.RepresentationMetadata(
+                local_resource_id="dd1b73b9-3e33-4264-968c-e3ce55b9afec",
+                api_href="https://apiHref.com/",
+                console_href="https://www.console.com/",
+                reporter_version="2.7.16",
+            )
 
-# Create the report request
-request = report_resource_request_pb2.ReportResourceRequest(
-    type="host",
-    reporter_type="hbi",
-    reporter_instance_id="0a2a430e-1ad9-4304-8e75-cc6fd3b5441a",
-    representations=representations,
-)
+            # Build the resource representations
+            representations = resource_representations_pb2.ResourceRepresentations(
+                metadata=metadata, common=common_struct, reporter=reporter_struct
+            )
 
-try:
-    response = stub.ReportResource(request)
-    print("Resource reported successfully")
-except grpc.RpcError as e:
-    print(f"Error reporting resource: {e.details()}")
+            # Create the report request
+            request = report_resource_request_pb2.ReportResourceRequest(
+                type="host",
+                reporter_type="hbi",
+                reporter_instance_id="3088be62-1c60-4884-b133-9200542d0b3f",
+                representations=representations,
+            )
+
+            response = stub.ReportResource(request)
+            print("Resource reported successfully")
+
+    except grpc.RpcError as e:
+        print("gRPC error occurred during ReportResource:")
+        print(f"Code: {e.code()}")
+        print(f"Details: {e.details()}")
+
+
+if __name__ == "__main__":
+    run()
 ```

--- a/src/content/sdk-examples-report-resources/python.md
+++ b/src/content/sdk-examples-report-resources/python.md
@@ -5,53 +5,57 @@ order: 20
 
 ```python
 import grpc
-
+from google.protobuf import struct_pb2
 from kessel.inventory.v1beta2 import (
     inventory_service_pb2_grpc,
-    check_request_pb2,
-    resource_reference_pb2,
-    reporter_reference_pb2,
-    subject_reference_pb2,
+    report_resource_request_pb2,
+    resource_representations_pb2,
+    representation_metadata_pb2,
 )
 
+stub = inventory_service_pb2_grpc.KesselInventoryServiceStub(
+    grpc.insecure_channel("localhost:9000")
+)
 
-def run():
-    stub = inventory_service_pb2_grpc.KesselInventoryServiceStub(
-        grpc.insecure_channel("localhost:9000")
-    )
+# Build protobuf Struct for common metadata
+common_struct = struct_pb2.Struct()
+common_struct.update({"workspace_id": "6eb10953-4ec9-4feb-838f-ba43a60880bf"})
 
-    # Prepare the subject reference object
-    subject = subject_reference_pb2.SubjectReference(
-        resource=resource_reference_pb2.ResourceReference(
-            reporter=reporter_reference_pb2.ReporterReference(type="rbac"),
-            resource_id="bob",
-            resource_type="principal",
-        )
-    )
+# Build protobuf Struct for reporter-specific data
+reporter_struct = struct_pb2.Struct()
+reporter_struct.update(
+    {
+        "satellite_id": "ca234d8f-9861-4659-a033-e80460b2801c",
+        "sub_manager_id": "e9b7d65f-3f81-4c26-b86c-2db663376eed",
+        "insights_inventory_id": "c4b9b5e7-a82a-467a-b382-024a2f18c129",
+        "ansible_host": "host-1",
+    }
+)
 
-    # Prepare the resource reference object
-    resource_ref = resource_reference_pb2.ResourceReference(
-        resource_id="bob_club",
-        resource_type="group",
-        reporter=reporter_reference_pb2.ReporterReference(type="rbac"),
-    )
+# Create metadata for the resource representation
+metadata = representation_metadata_pb2.RepresentationMetadata(
+    local_resource_id="854589f0-3be7-4cad-8bcd-45e18f33cb81",
+    api_href="https://apiHref.com/",
+    console_href="https://www.consoleHref.com/",
+    reporter_version="0.2.11",
+)
 
-    check_request = check_request_pb2.CheckRequest(
-        subject=subject,
-        relation="member",
-        object=resource_ref,
-    )
+# Build the resource representations
+representations = resource_representations_pb2.ResourceRepresentations(
+    metadata=metadata, common=common_struct, reporter=reporter_struct
+)
 
-    try:
-        check_response = stub.Check(check_request)
-        print("Check response received successfully")
-        print(check_response)
-    except grpc.RpcError as e:
-        print("gRPC error occurred during Check:")
-        print(f"Code: {e.code()}")
-        print(f"Details: {e.details()}")
+# Create the report request
+request = report_resource_request_pb2.ReportResourceRequest(
+    type="host",
+    reporter_type="hbi",
+    reporter_instance_id="0a2a430e-1ad9-4304-8e75-cc6fd3b5441a",
+    representations=representations,
+)
 
-
-if __name__ == "__main__":
-    run()
+try:
+    response = stub.ReportResource(request)
+    print("Resource reported successfully")
+except grpc.RpcError as e:
+    print(f"Error reporting resource: {e.details()}")
 ```

--- a/src/content/sdk-examples-report-resources/ruby.md
+++ b/src/content/sdk-examples-report-resources/ruby.md
@@ -8,42 +8,48 @@ order: 50
 # frozen_string_literal: true
 
 require 'dotenv/load'
+require 'json'
 require 'kessel-sdk'
 
 include Kessel::Inventory::V1beta2
 
 client = KesselInventoryService::Stub.new(ENV.fetch('KESSEL_ENDPOINT', nil), :this_channel_is_insecure)
 
-subject_reference = SubjectReference.new(
-  resource: ResourceReference.new(
-    reporter: ReporterReference.new(
-      type: 'rbac'
-    ),
-    resource_id: 'foobar',
-    resource_type: 'principal'
-  )
+common = Google::Protobuf::Struct.decode_json({ 'workspace_id' => '6eb10953-4ec9-4feb-838f-ba43a60880bf' }.to_json)
+
+reporter = Google::Protobuf::Struct.decode_json({
+  'satellite_id' => 'ca234d8f-9861-4659-a033-e80460b2801c',
+  'sub_manager_id' => 'e9b7d65f-3f81-4c26-b86c-2db663376eed',
+  'insights_inventory_id' => 'c4b9b5e7-a82a-467a-b382-024a2f18c129',
+  'ansible_host' => 'host-1'
+}.to_json)
+
+metadata = RepresentationMetadata.new(
+  local_resource_id: '854589f0-3be7-4cad-8bcd-45e18f33cb81',
+  api_href: 'https://apiHref.com/',
+  console_href: 'https://www.consoleHref.com/',
+  reporter_version: '0.2.11'
 )
 
-resource = ResourceReference.new(
-  reporter: ReporterReference.new(
-    type: 'rbac'
-  ),
-  resource_id: '1234',
-  resource_type: 'workspace'
+representations = ResourceRepresentations.new(
+  metadata: metadata,
+  common: common,
+  reporter: reporter
 )
 
 begin
-  response = client.check(
-    CheckRequest.new(
-      object: resource,
-      relation: 'inventory_host_view',
-      subject: subject_reference
+  response = client.report_resource(
+    ReportResourceRequest.new(
+      type: 'host',
+      reporter_type: 'hbi',
+      reporter_instance_id: '0a2a430e-1ad9-4304-8e75-cc6fd3b5441a',
+      representations: representations
     )
   )
-  p 'check response received successfully:'
+  p 'report_resource response received successfully:'
   p response
 rescue Exception => e
-  p 'gRPC error occurred during check:'
+  p 'gRPC error occurred during report_resource:'
   p "Exception #{e}"
 end
 ```

--- a/src/content/sdk-examples-report-resources/ruby.md
+++ b/src/content/sdk-examples-report-resources/ruby.md
@@ -13,22 +13,35 @@ require 'kessel-sdk'
 
 include Kessel::Inventory::V1beta2
 
-client = KesselInventoryService::Stub.new(ENV.fetch('KESSEL_ENDPOINT', nil), :this_channel_is_insecure)
+# For authenticated environments, uncomment and configure the following:
+# auth_credentials = OAuth2ClientCredentials.new(
+#   client_id: CLIENT_ID,
+#   client_secret: CLIENT_SECRET,
+#   token_endpoint: "#{ISSUER_URL}/token"
+# )
+# client = KesselInventoryService::ClientBuilder.new(KESSEL_ENDPOINT)
+#                                               .oauth2_client_authenticated(auth_credentials)
+#                                               .build
 
-common = Google::Protobuf::Struct.decode_json({ 'workspace_id' => '6eb10953-4ec9-4feb-838f-ba43a60880bf' }.to_json)
+# For insecure local development:
+client = KesselInventoryService::ClientBuilder.new(KESSEL_ENDPOINT)
+                                              .insecure
+                                              .build
+
+common = Google::Protobuf::Struct.decode_json({ 'workspace_id' => 'a64d17d0-aec3-410a-acd0-e0b85b22c076' }.to_json)
 
 reporter = Google::Protobuf::Struct.decode_json({
   'satellite_id' => 'ca234d8f-9861-4659-a033-e80460b2801c',
   'sub_manager_id' => 'e9b7d65f-3f81-4c26-b86c-2db663376eed',
-  'insights_inventory_id' => 'c4b9b5e7-a82a-467a-b382-024a2f18c129',
+  'insights_inventory_id' => '05707922-7b0a-4fe6-982d-6adbc7695b8f',
   'ansible_host' => 'host-1'
 }.to_json)
 
 metadata = RepresentationMetadata.new(
-  local_resource_id: '854589f0-3be7-4cad-8bcd-45e18f33cb81',
+  local_resource_id: 'dd1b73b9-3e33-4264-968c-e3ce55b9afec',
   api_href: 'https://apiHref.com/',
-  console_href: 'https://www.consoleHref.com/',
-  reporter_version: '0.2.11'
+  console_href: 'https://www.console.com/',
+  reporter_version: '2.7.16'
 )
 
 representations = ResourceRepresentations.new(
@@ -42,14 +55,14 @@ begin
     ReportResourceRequest.new(
       type: 'host',
       reporter_type: 'hbi',
-      reporter_instance_id: '0a2a430e-1ad9-4304-8e75-cc6fd3b5441a',
+      reporter_instance_id: '3088be62-1c60-4884-b133-9200542d0b3f',
       representations: representations
     )
   )
-  p 'report_resource response received successfully:'
+  puts 'report_resource response received successfully:'
   p response
-rescue Exception => e
-  p 'gRPC error occurred during report_resource:'
-  p "Exception #{e}"
+rescue => e
+  puts 'gRPC error occurred during report_resource:'
+  puts "Exception: #{e}"
 end
 ```

--- a/src/examples/host/common_representation.json
+++ b/src/examples/host/common_representation.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "properties": {
+    "workspace_id": {
+      "type": "string"
+    }
+  },
+  "required": ["workspace_id"]
+}

--- a/src/examples/host/config.yaml
+++ b/src/examples/host/config.yaml
@@ -1,0 +1,3 @@
+resource_type: host
+resource_reporters:
+  - hbi

--- a/src/examples/host/reporters/hbi/config.yaml
+++ b/src/examples/host/reporters/hbi/config.yaml
@@ -1,0 +1,3 @@
+resource_type: host
+reporter_name: hbi
+namespace: hbi

--- a/src/examples/host/reporters/hbi/host.json
+++ b/src/examples/host/reporters/hbi/host.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "properties": {
+    "insights_inventory_id": {
+      "type": "string",
+      "format": "uuid"
+    }
+  },
+  "required": []
+}

--- a/src/examples/rbac.ksl
+++ b/src/examples/rbac.ksl
@@ -1,0 +1,2 @@
+// KSL schema for RBAC
+// TODO: Add actual KSL content for RBAC

--- a/src/examples/resource_relationships_schema.ksl
+++ b/src/examples/resource_relationships_schema.ksl
@@ -1,0 +1,2 @@
+// KSL schema for resource relationships
+// TODO: Add actual KSL content for resource relationships


### PR DESCRIPTION
- Fixes the check & request resource examples (They were swapped)
- - Updates examples to use clientbuilder & comments for authentication
- - Added curl examples
- Organizes schemas into explicitly defined example files.