### PR TITLE
Add AI agent readiness documentation

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
+# See https://docs.coderabbit.ai/reference/configuration for all fields and default values
+knowledge_base:
+  code_guidelines:
+    filePatterns:
+      - "docs/*-guidelines.md"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,149 @@
+# AGENTS.md
+
+This file provides onboarding context for AI agents working in the `docs` repository. It covers cross-cutting conventions, architectural context, and pointers to detailed guidelines. For the project overview, see [README.md](README.md). For contribution basics, see [CONTRIBUTING.md](CONTRIBUTING.md).
+
+## Guidelines Index
+
+Detailed domain-specific guidelines are maintained in the `docs/` directory. Read these before making changes in the relevant area:
+
+| Guideline | Covers |
+|-----------|--------|
+| [docs/api-contracts-guidelines.md](docs/api-contracts-guidelines.md) | API versioning (v1beta2), SDK conventions, ClientBuilder, protobuf message structures, CloudEvents, KSL schema, code example patterns |
+| [docs/security-guidelines.md](docs/security-guidelines.md) | OAuth2 client credentials, TLS configuration, SpiceDB authorization model, KSL permissions, role bindings, Kafka SASL auth |
+| [docs/integration-guidelines.md](docs/integration-guidelines.md) | Kessel architecture (Inventory + Relations APIs), resource reporting patterns, outbox/CDC, Kafka consumers, SDK integration docs |
+| [docs/performance-guidelines.md](docs/performance-guidelines.md) | gRPC channel reuse, token caching, native compilation in CI, CDC monitoring KPIs, Kafka consumer performance, LISTEN/NOTIFY |
+| [docs/error-handling-guidelines.md](docs/error-handling-guidelines.md) | Language-specific gRPC error handling, retry patterns, monitoring metrics, TLS errors, Astro/Zod schema errors |
+| [docs/database-guidelines.md](docs/database-guidelines.md) | Inventory DB schema conventions, outbox table structure, Debezium CDC, Kafka event schemas, Mermaid diagrams |
+
+## What This Repository Is
+
+This is an **Astro/Starlight documentation site**, not an application runtime. There is no database, no server, no deployed backend code. The content documents Kessel integration patterns for external service providers. Understand this distinction before making changes -- do not introduce runtime logic, backend code, or application error handling into the site itself.
+
+Key technology stack:
+- **Astro 5** with **Starlight** documentation theme
+- **Tailwind CSS v4** (via Vite plugin)
+- **TypeScript** in strict mode (`astro/tsconfigs/strict`)
+- **Zod** for frontmatter schema validation
+- **starlight-openapi** plugin pulling the OpenAPI spec from `inventory-api` at build time
+- **marked** for Markdown rendering in custom components
+
+## Build and CI
+
+Commands (run from repo root):
+- `npm run dev` -- local dev server at `localhost:4321`
+- `npm run build` -- runs `astro check && astro build`, outputs to `./dist/`
+- `npm run preview` -- preview the built site locally
+
+CI pipeline (`.github/workflows/ci.yml`): runs `withastro/action@v2` on every PR to `main`. This performs `npm install` and a full build. If the build fails, the PR cannot merge.
+
+Deployment (`.github/workflows/deploy.yml`): on push to `main`, builds and deploys to GitHub Pages. Only runs when `github.repository == 'project-kessel/docs'` (not on forks).
+
+The site is served at `https://project-kessel.github.io/docs/` with `base: "docs"`.
+
+## Repository Structure
+
+```
+src/
+  content/docs/           # Documentation pages (.md and .mdx)
+    building-with-kessel/   # User-facing docs (how-to, concepts, reference, archive)
+    contributing/           # SDK spec, client API reference, writing guide
+    running-kessel/         # Architecture, installation, monitoring
+    start-here/             # Getting started, understanding Kessel
+  components/             # Custom Astro components
+  examples/               # Code examples in multiple languages
+  middleware/             # Starlight route middleware
+  schemas/                # Zod schemas for frontmatter validation
+  styles/                 # Global CSS (minimal custom styles)
+docs/                     # AI agent guidelines (this index points here)
+public/                   # Static assets (favicon)
+```
+
+## Content Authoring Conventions
+
+### File format
+- Use `.mdx` for pages that need Astro components (`Aside`, `Tabs`, `TabItem`, `Code`, `LinkCard`, `CodeExamples`, etc.). Use `.md` for pure Markdown content.
+- Frontmatter is required. At minimum: `title` and `description`.
+- Use `sidebar.order` in frontmatter to control navigation ordering (lower numbers first).
+
+### Diataxis model
+This project follows the [Diataxis](https://diataxis.fr/) documentation framework. Know whether you are writing a tutorial, how-to guide, explanation, or reference, and write accordingly. See `src/content/docs/contributing/documentation.mdx` for full principles.
+
+### Current vs. archived content
+- Current docs go under `building-with-kessel/how-to/` or `building-with-kessel/concepts/`.
+- Deprecated content (v1beta1) goes under `building-with-kessel/archive/` with a deprecation notice.
+- Archive content is collapsed in the sidebar with an "Outdated" badge. Do not treat it as current guidance.
+
+### Diagrams
+- Use **Mermaid** syntax directly in `.md`/`.mdx` files. ER diagrams use `erDiagram`, flow diagrams use `flowchart LR`.
+
+## Code Examples
+
+### Location and structure
+Examples live in `src/examples/` organized by topic (e.g., `getting-started/`, `tls/`). Each topic has the same example implemented in multiple languages.
+
+### Supported languages and file naming
+Files follow the pattern `example.{ext}` or `example.{variant}.{ext}`:
+- `.go` (Go), `.py` (Python), `.ts` (TypeScript), `.rb` (Ruby), `.java` (Java), `.sh` (Bash)
+- Variant naming: `example.curl.sh` and `example.grpcurl.sh` produce separate tabs ("curl" and "grpcurl")
+
+### Region markers
+Examples use region markers for selective inclusion in docs via the `CodeExamples` component:
+- C-style languages (Go, TS, Java): `//#region name` and `//#endregion`
+- Hash-style languages (Python, Ruby, Bash): `# region name` and `# endregion`
+
+All important code (including error handling) must be inside the appropriate region to render correctly.
+
+### CodeExamples component usage
+In `.mdx` files:
+```mdx
+import CodeExamples from 'src/components/CodeExamples.astro';
+export const files = import.meta.glob('/src/examples/topic/example.*', { query: '?raw', eager: true, import: 'default' });
+<CodeExamples files={files} regions="regionName" />
+```
+
+The component auto-sorts tabs by language (Bash, Python, Go, JS, TS, Ruby, Java).
+
+## Client Package Documentation System
+
+Pages with `docType: client-package` in frontmatter use a structured `package` field (validated by `src/schemas/client-package.ts`) to auto-generate API reference documentation. The schema supports `interfaces`, `classes` (with constructors, properties, methods, statics), and `functions`. Methods and constructors can be scoped to specific languages via an optional `languages` array.
+
+This system has three cooperating parts:
+1. **Zod schema** (`src/schemas/client-package.ts`) -- validates the frontmatter structure
+2. **MarkdownContent override** (`src/components/MarkdownContent.astro`) -- detects `docType: client-package` and renders `ClientPackageDescription` instead of default content
+3. **Route middleware** (`src/middleware/client-package-toc.ts`) -- generates table-of-contents headings from the package structure
+
+When editing client-package pages, the API surface is defined entirely in YAML frontmatter, not in the Markdown body. The specification uses JavaScript conventions (`camelCase`) as canonical; implementations transform to language-specific conventions.
+
+## Fork and Overlay Architecture
+
+This repository is designed to be forked for internal documentation. The `config-overlay.mjs` file provides two hook functions:
+- `applyTopLevelOverlay(config)` -- modifies top-level Astro config (site URL, base path, integrations)
+- `applyStarlightOverlay(starlightConfig)` -- modifies Starlight config (sidebar entries, plugins)
+
+**Critical rule**: In the public repository, changes to `config-overlay.mjs` and `astro.config.mjs` must be made carefully as they affect internal forks. The warning in `config-overlay.mjs` is explicit: modifications may break internal mirroring. In a fork, you MUST NOT modify files that originate from the public repository.
+
+## Cross-Cutting Conventions
+
+### API version references
+The current version is **v1beta2**. All new content must reference v1beta2 paths (`/api/kessel/v1beta2/...`) and gRPC namespaces (`kessel.inventory.v1beta2`). Do not introduce v1beta1 references outside of `archive/`.
+
+### Custom CSS policy
+Custom CSS is discouraged. The comment in `src/styles/global.css` states: "Use custom css only in exceptional circumstances." Prefer Starlight's built-in theming and Tailwind utilities.
+
+### TypeScript
+Strict mode is enforced. Path aliases are configured: `src/*` maps to `./src/*`. Zod schemas use `.optional().default(false)` for boolean fields -- maintain this pattern.
+
+### Security in examples
+- Never include real credentials. Use placeholders (`"your-client-id"`, `<PASSWORD>`).
+- Getting-started examples use `insecure()` mode with a comment indicating it is for local development only.
+- TLS examples demonstrate loading CA certificates, never disabling TLS verification.
+
+### External references
+- Link to Buf Schema Registry for protobuf types rather than duplicating definitions.
+- The OpenAPI spec is pulled from `project-kessel/inventory-api` at build time -- do not vendor it.
+- Cross-references to Red Hat internal guides must note VPN requirements.
+
+### PR expectations
+- Every code or system change must be accompanied by documentation updates.
+- The CI build (`astro check && astro build`) must pass -- TypeScript errors and broken references will fail the build.
+- Comment the API spec (protobuf) if your change affects API behavior.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,6 +15,33 @@ Detailed domain-specific guidelines are maintained in the `docs/` directory. Rea
 | [docs/error-handling-guidelines.md](docs/error-handling-guidelines.md) | Language-specific gRPC error handling, retry patterns, monitoring metrics, TLS errors, Astro/Zod schema errors |
 | [docs/database-guidelines.md](docs/database-guidelines.md) | Inventory DB schema conventions, outbox table structure, Debezium CDC, Kafka event schemas, Mermaid diagrams |
 
+## Source Repositories
+
+This documentation project references multiple source code repositories. The `docs/sources.yaml` file lists all relevant repositories and metadata. AI agents use this file to:
+
+- Discover which repositories to analyze
+- Understand repository types (api, sdk, schema, service)
+- Get GitHub URLs for cloning if needed
+- Generate documentation from implementation details
+
+The file structure:
+
+```yaml
+repositories:
+  - name: inventory-api
+    type: api
+    github: https://github.com/project-kessel/inventory-api
+    description: Brief description
+    technologies: [Go, gRPC, ...]
+```
+
+**To locate repositories locally:**
+1. Check parent directory: `../repository-name/`
+2. Search common project directories
+3. If not found, ask the user for the path or offer to clone from GitHub
+
+When generating documentation from source code (e.g., explaining architectural patterns, documenting APIs), always check `docs/sources.yaml` first to discover relevant repositories. If you discover new repositories that should be documented, suggest updating this file.
+
 ## What This Repository Is
 
 This is an **Astro/Starlight documentation site**, not an application runtime. There is no database, no server, no deployed backend code. The content documents Kessel integration patterns for external service providers. Understand this distinction before making changes -- do not introduce runtime logic, backend code, or application error handling into the site itself.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,57 @@
+# Claude Code Configuration
+
+@AGENTS.md
+
+## Build and Development Commands
+
+This is an Astro/Starlight documentation site. When working in this repository:
+
+### Development workflow
+- **Start dev server**: `npm run dev` (serves at `localhost:4321`)
+- **Build the site**: `npm run build` (runs `astro check && astro build`, outputs to `./dist/`)
+- **Preview build**: `npm run preview` (preview the built site locally)
+
+### Before committing
+- Always run `npm run build` to verify TypeScript checks and build pass
+- The CI pipeline runs `astro check && astro build` - your changes must pass this
+- If you get TypeScript errors, the build will fail - fix them before committing
+
+### Pre-commit hooks
+This repository uses `rh-multi-pre-commit` for Red Hat security scanning. The hook runs automatically on commit. If you encounter hook failures unrelated to your changes, notify the team.
+
+## Claude Code Behavioral Preferences
+
+### File modification priority
+- **CRITICAL**: This repository has a fork/overlay architecture for internal documentation
+- Modifications to `config-overlay.mjs` and `astro.config.mjs` affect internal forks - exercise extreme caution
+- The warning in `config-overlay.mjs` is explicit: modifications may break internal mirroring
+- When making changes to these files, follow up immediately to resolve conflicts in forks
+
+### Content creation
+- Use `.mdx` for pages needing Astro components (`Aside`, `Tabs`, `CodeExamples`, etc.)
+- Use `.md` for pure Markdown content
+- All frontmatter must include at minimum: `title` and `description`
+- Follow the Diataxis framework - know if you're writing tutorial, how-to, explanation, or reference
+
+### Code examples
+- Examples live in `src/examples/` organized by topic
+- Use region markers for selective inclusion:
+  - C-style languages (Go, TS, Java): `//#region name` and `//#endregion`
+  - Hash-style languages (Python, Ruby, Bash): `# region name` and `# endregion`
+- All important code including error handling must be inside regions
+
+### TypeScript
+- Strict mode is enforced via `astro/tsconfigs/strict`
+- Path alias `src/*` maps to `./src/*`
+- Zod schemas use `.optional().default(false)` for boolean fields - maintain this pattern
+
+### CSS
+- Custom CSS is discouraged - the comment in `src/styles/global.css` states: "Use custom css only in exceptional circumstances"
+- Prefer Starlight's built-in theming and Tailwind utilities
+
+## Repository-Specific Notes
+
+- **No runtime logic**: This is a documentation site, not an application. Do not introduce backend code, database logic, or application error handling
+- **Current API version**: v1beta2 - all references must use v1beta2 paths and namespaces
+- **Security in examples**: Never include real credentials. Use placeholders like `"your-client-id"` or `<PASSWORD>`
+- **OpenAPI spec**: Pulled from `project-kessel/inventory-api` at build time - do not vendor it

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,29 +1,30 @@
 # Contributing
 
-## 🚀 Project Structure
+## Project Structure
 
-Inside of your Astro + Starlight project, you'll see the following folders and files:
+This is the Kessel documentation site built with Astro and Starlight. The structure is organized as follows:
 
 ```
-.
-├── public/
-├── src/
-│   ├── assets/
-│   ├── content/
-│   │   ├── docs/
-│   │   └── config.ts
-│   └── env.d.ts
-├── astro.config.mjs
-├── package.json
-├── tailwind.config.mjs
-└── tsconfig.json
+src/
+  content/docs/             # Documentation pages (.md and .mdx)
+    building-with-kessel/     # How-to guides, concepts, reference, archive
+    contributing/             # SDK spec, client API reference, writing guide
+    running-kessel/           # Architecture, installation, monitoring
+    start-here/               # Getting started, understanding Kessel
+  components/               # Custom Astro components
+  examples/                 # Code examples (Go, Python, TypeScript, Ruby, Java, Bash)
+  middleware/               # Starlight route middleware
+  schemas/                  # Zod schemas for frontmatter validation
+  styles/                   # Global CSS
+docs/                       # AI agent guidelines
+public/                     # Static assets (favicon)
+astro.config.mjs            # Astro and Starlight configuration
+config-overlay.mjs          # Fork/overlay hooks for internal documentation
 ```
 
 Starlight looks for `.md` or `.mdx` files in the `src/content/docs/` directory. Each file is exposed as a route based on its file name.
 
-Images can be added to `src/assets/` and embedded in Markdown with a relative link.
-
-Static assets, like favicons, can be placed in the `public/` directory.
+Code examples are organized by topic in `src/examples/` with implementations in multiple languages. They use region markers for selective inclusion in documentation.
 
 ## 🧞 Commands
 

--- a/README.md
+++ b/README.md
@@ -3,3 +3,75 @@
 [![Built with Starlight](https://astro.badg.es/v2/built-with-starlight/tiny.svg)](https://starlight.astro.build)
 
 [Kessel Documentation](https://project-kessel.github.io/docs/)
+
+## About
+
+This repository contains the source for the [Kessel](https://github.com/project-kessel) documentation site. Kessel is a platform that provides a unified inventory of resources, their relationships, and their changes over time. It offers primitives for resource organization, sharing, entitlement, history tracking, and event publishing -- along with an opinionated RBAC and tenancy model via Kessel RBAC.
+
+This site documents integration patterns, SDK usage, API references, and operational guides for teams building with or running Kessel.
+
+## Tech Stack
+
+- [Astro 5](https://astro.build/) with [Starlight](https://starlight.astro.build/) documentation theme
+- [Tailwind CSS v4](https://tailwindcss.com/) via Vite plugin
+- [TypeScript](https://www.typescriptlang.org/) in strict mode
+- [Zod](https://zod.dev/) for frontmatter schema validation
+- [starlight-openapi](https://github.com/HiDeoo/starlight-openapi) plugin (pulls the OpenAPI spec from [inventory-api](https://github.com/project-kessel/inventory-api) at build time)
+- [marked](https://marked.js.org/) for Markdown rendering in custom components
+
+## Quick Start
+
+```bash
+# Install dependencies
+npm install
+
+# Start the dev server at localhost:4321
+npm run dev
+
+# Build for production (runs astro check && astro build, outputs to ./dist/)
+npm run build
+
+# Preview the production build locally
+npm run preview
+```
+
+## Project Structure
+
+```
+src/
+  content/docs/             # Documentation pages (.md and .mdx)
+    building-with-kessel/     # How-to guides, concepts, reference, archive
+    contributing/             # SDK spec, client API reference, writing guide
+    running-kessel/           # Architecture, installation, monitoring
+    start-here/               # Getting started, understanding Kessel
+  components/               # Custom Astro components
+  examples/                 # Code examples (Go, Python, TypeScript, Ruby, Java, Bash)
+  middleware/               # Starlight route middleware
+  schemas/                  # Zod schemas for frontmatter validation
+  styles/                   # Global CSS
+docs/                       # AI agent guidelines
+public/                     # Static assets (favicon)
+astro.config.mjs            # Astro and Starlight configuration
+config-overlay.mjs          # Fork/overlay hooks for internal documentation
+```
+
+## Fork and Overlay Support
+
+This repository is designed to be forked for internal documentation. The `config-overlay.mjs` file provides hook functions to modify the Astro and Starlight configuration (e.g., adding sidebar entries for internal docs) without altering upstream files. See [CONTRIBUTING.md](CONTRIBUTING.md) for details.
+
+## Further Reading
+
+| Resource | Description |
+|----------|-------------|
+| [CONTRIBUTING.md](CONTRIBUTING.md) | Project structure, commands, writing documentation, and fork/overlay guidance |
+| [AGENTS.md](AGENTS.md) | Onboarding context for AI agents: conventions, architecture, and pointers to detailed guidelines |
+| [docs/api-contracts-guidelines.md](docs/api-contracts-guidelines.md) | API versioning, SDK conventions, protobuf structures, code example patterns |
+| [docs/security-guidelines.md](docs/security-guidelines.md) | OAuth2, TLS, SpiceDB authorization, Kafka SASL auth |
+| [docs/integration-guidelines.md](docs/integration-guidelines.md) | Kessel architecture, resource reporting, outbox/CDC, Kafka consumers |
+| [docs/performance-guidelines.md](docs/performance-guidelines.md) | gRPC channel reuse, token caching, CDC monitoring, Kafka performance |
+| [docs/error-handling-guidelines.md](docs/error-handling-guidelines.md) | Language-specific gRPC error handling, retry patterns, TLS errors |
+| [docs/database-guidelines.md](docs/database-guidelines.md) | Inventory DB schema, outbox table, Debezium CDC, Kafka event schemas |
+
+## License
+
+See [LICENSE](LICENSE).

--- a/docs/api-contracts-guidelines.md
+++ b/docs/api-contracts-guidelines.md
@@ -4,10 +4,13 @@ This is the Kessel documentation site (Astro/Starlight). It documents API contra
 
 ## API Versioning
 
-- The current API version is **v1beta2**. The v1beta1 API is deprecated and archived.
-- API paths follow the pattern `/api/kessel/{api-version}/...` (e.g., `/api/kessel/v1beta2/resources`, `/api/kessel/v1beta2/check`).
-- gRPC service names use the pattern `kessel.{service}.v1beta2.{ServiceName}` (e.g., `kessel.inventory.v1beta2.KesselInventoryService`, `kessel.relations.v1beta2.KesselTupleService`).
-- Protobuf definitions are hosted on the Buf Schema Registry at `buf.build/project-kessel/inventory-api`.
+- **Inventory API** uses **v1beta2** as the current version. The v1beta1 API is deprecated and archived.
+- **Relations API** uses **v1beta1** for all protos.
+- API paths follow the pattern `/api/kessel/{api-version}/...` (e.g., `/api/kessel/v1beta2/resources` for inventory).
+- gRPC service names use the pattern `kessel.{service}.{version}.{ServiceName}`:
+  - Inventory: `kessel.inventory.v1beta2.KesselInventoryService`
+  - Relations: `kessel.relations.v1beta1.KesselTupleService`
+- Protobuf definitions are hosted on the Buf Schema Registry at `buf.build/project-kessel/inventory-api` and `buf.build/project-kessel/relations-api`.
 - The OpenAPI spec is pulled from `https://raw.githubusercontent.com/project-kessel/inventory-api/refs/heads/main/openapi.yaml`.
 
 ## SDK Client Library Conventions
@@ -89,20 +92,16 @@ Resource types are configured via a directory structure under `data/schema/resou
 
 ## Relations API (Tuples)
 
-- Roles are created by writing tuples to `kessel.relations.v1beta2.KesselTupleService.CreateTuples`.
+- Roles are created by writing tuples to `kessel.relations.v1beta1.KesselTupleService.CreateTuples`.
 - Resource/subject references use `type.name` + `type.namespace` (e.g., `name: "role", namespace: "rbac"`).
 - Role bindings require three tuples in a single `CreateTuples` call: binding->granted->role, binding->subject->principal, workspace->user_grant->binding.
 - Binding IDs follow the deterministic pattern `{role}--{user}--{resource}`.
 
-## SDK Package Frontmatter Schema
+## Code Example and Documentation Conventions
 
-Client API reference docs use `docType: client-package` in frontmatter with a structured `package` field containing `interfaces`, `classes`, and `functions`. This schema is validated by `src/schemas/client-package.ts` (Zod). Each class can have `constructors`, `properties`, `methods`, and `statics`. Methods/functions can be scoped to specific languages via an optional `languages` array.
+For SDK package documentation patterns, code example structure, and region markers, see the [Code Examples](../AGENTS.md#code-examples) and [Client Package Documentation System](../AGENTS.md#client-package-documentation-system) sections in AGENTS.md.
 
-## Code Example Conventions
-
-- Examples in `src/examples/getting-started/` cover all supported languages: Go, Python, TypeScript, Ruby, Java, curl, and grpcurl.
-- Examples use region markers (`//#region`, `//#endregion`, `# region`, `# endregion`) for selective inclusion in docs via the `CodeExamples` component.
-- All SDK examples demonstrate the same scenario with identical resource data across languages.
+Additional API-specific conventions:
 - Async messaging examples (Kafka consumers, outbox pattern) use the Go `confluent-kafka-go` library as the reference implementation.
 - SASL authentication with SCRAM-SHA-512 is the standard for Kafka consumers.
 

--- a/docs/api-contracts-guidelines.md
+++ b/docs/api-contracts-guidelines.md
@@ -1,0 +1,113 @@
+## Repository Purpose
+
+This is the Kessel documentation site (Astro/Starlight). It documents API contracts for the Kessel platform -- a multi-tenant resource management and access control system. Content covers gRPC/REST APIs, SDK specifications, CloudEvents schemas, and schema languages (KSL/SpiceDB).
+
+## API Versioning
+
+- The current API version is **v1beta2**. The v1beta1 API is deprecated and archived.
+- API paths follow the pattern `/api/kessel/{api-version}/...` (e.g., `/api/kessel/v1beta2/resources`, `/api/kessel/v1beta2/check`).
+- gRPC service names use the pattern `kessel.{service}.v1beta2.{ServiceName}` (e.g., `kessel.inventory.v1beta2.KesselInventoryService`, `kessel.relations.v1beta2.KesselTupleService`).
+- Protobuf definitions are hosted on the Buf Schema Registry at `buf.build/project-kessel/inventory-api`.
+- The OpenAPI spec is pulled from `https://raw.githubusercontent.com/project-kessel/inventory-api/refs/heads/main/openapi.yaml`.
+
+## SDK Client Library Conventions
+
+- SDKs are scoped to **Kessel as a whole**, not individual services. Import prefixes include "kessel" (e.g., `kessel.inventory.v1beta2`, `@project-kessel/kessel-sdk`).
+- Import hierarchy follows the pattern `{prefix}.{service}.{major_version}` and is consistent across languages:
+  - `{prefix}.auth` -- generic authentication abstractions
+  - `{prefix}.grpc` -- gRPC-specific utilities (must not import peer packages)
+  - `{prefix}.http` -- HTTP-specific utilities (must not import peer packages)
+  - `{prefix}.middleware` -- transport-agnostic middleware
+  - `{prefix}.{service}.{major_version}` -- version-specific generated code and utilities
+- Case conventions follow each language's idioms (e.g., `snake_case` in Python, `camelCase` in JS/TS) but the specification uses JavaScript conventions as canonical.
+- Client stubs are generated from API specifications using `buf` for gRPC and `openapi-generator` for HTTP. Generation is reproducible with pinned plugin versions.
+
+## ClientBuilder Pattern
+
+Every `{service}.{major_version}` package exposes a `ClientBuilder` class:
+
+- Constructor takes a `target` URI string (gRPC endpoint).
+- Authentication methods: `oauth2ClientAuthenticated(credentials)`, `authenticated(callCredentials, channelCredentials)`, `unauthenticated(channelCredentials)`, `insecure()`.
+- `build()` returns the stub (and channel if the stub lacks `close()`). `buildAsync()` is required for Python and JavaScript.
+- Default behavior: TLS with runtime default trust bundle. No deadlines, retries, or load balancing -- these come from gRPC service config.
+- Insecure mode is only for local development/testing.
+
+## ReportResource Request Structure (v1beta2)
+
+The `ReportResourceRequest` protobuf message requires:
+- `type` -- resource type string (e.g., `"document"`)
+- `reporter_type` -- reporter identifier (e.g., `"drive"`)
+- `reporter_instance_id` -- unique reporter instance
+- `representations` containing:
+  - `metadata` (`RepresentationMetadata`): `local_resource_id`, `api_href`, `console_href`, `reporter_version`
+  - `common` (`google.protobuf.Struct`): shared attributes across reporters (e.g., `workspace_id`)
+  - `reporter` (`google.protobuf.Struct`): reporter-specific attributes
+
+## Check Request Structure (v1beta2)
+
+The `CheckRequest` requires:
+- `object` (`ResourceReference`): `resource_type`, `resource_id`, `reporter` (`ReporterReference` with `type`)
+- `relation` -- permission to check (e.g., `"view"`)
+- `subject` (`SubjectReference`): contains a `resource` (`ResourceReference`) identifying the subject
+
+Principals use `resource_type: "principal"` with `reporter.type: "rbac"`.
+
+## CloudEvents Schema
+
+Events follow CloudEvents 1.0 with these Kessel conventions:
+- `type`: `redhat.inventory.resources.{resource_type}.{operation}` where operation is `created`, `updated`, or `deleted`
+- `type` for relationships: `redhat.inventory.resources-relationship.{relationship_type}.{operation}`
+- `subject`: `/resources/{resource_type}/{id}` or `/resources-relationships/{relationship_type}/{id}`
+- `source`: the inventory API URI
+- `datacontenttype`: always `"application/json"`
+- `data` payload contains `metadata`, `reporter_data`, and `resource_data` (or `relationship_data`)
+
+## Resource Schema Configuration
+
+Resource types are configured via a directory structure under `data/schema/resources/` in the inventory-api repository:
+
+```
+{resource_type}/
+  config.yaml              # resource_type name + list of reporters
+  common_representation.json  # JSON Schema for shared attributes
+  reporters/{reporter}/
+    config.yaml            # reporter_name + namespace
+    {resource_type}.json   # JSON Schema for reporter-specific attributes
+```
+
+- `config.yaml` lists `resource_type` and `resource_reporters`
+- Reporter `config.yaml` specifies `resource_type`, `reporter_name`, and `namespace`
+- JSON Schemas use draft-07
+
+## Permission Schema (KSL)
+
+- Permissions are defined in `.ksl` files using the KSL schema language (version 0.1).
+- Built-in schemas (`kessel.ksl`, `rbac.ksl`) are present in examples. Custom schemas import `rbac` and use extensions.
+- Permissions are added via `@rbac.add_permission(name:'permission_name')` annotations.
+- Resource types declare `relation workspace: [ExactlyOne rbac.workspace]` and derive permissions from workspace-level grants: `relation view: workspace.view_document`.
+- KSL compiles to SpiceDB `.zed` schema via the `ksl` compiler.
+
+## Relations API (Tuples)
+
+- Roles are created by writing tuples to `kessel.relations.v1beta2.KesselTupleService.CreateTuples`.
+- Resource/subject references use `type.name` + `type.namespace` (e.g., `name: "role", namespace: "rbac"`).
+- Role bindings require three tuples in a single `CreateTuples` call: binding->granted->role, binding->subject->principal, workspace->user_grant->binding.
+- Binding IDs follow the deterministic pattern `{role}--{user}--{resource}`.
+
+## SDK Package Frontmatter Schema
+
+Client API reference docs use `docType: client-package` in frontmatter with a structured `package` field containing `interfaces`, `classes`, and `functions`. This schema is validated by `src/schemas/client-package.ts` (Zod). Each class can have `constructors`, `properties`, `methods`, and `statics`. Methods/functions can be scoped to specific languages via an optional `languages` array.
+
+## Code Example Conventions
+
+- Examples in `src/examples/getting-started/` cover all supported languages: Go, Python, TypeScript, Ruby, Java, curl, and grpcurl.
+- Examples use region markers (`//#region`, `//#endregion`, `# region`, `# endregion`) for selective inclusion in docs via the `CodeExamples` component.
+- All SDK examples demonstrate the same scenario with identical resource data across languages.
+- Async messaging examples (Kafka consumers, outbox pattern) use the Go `confluent-kafka-go` library as the reference implementation.
+- SASL authentication with SCRAM-SHA-512 is the standard for Kafka consumers.
+
+## Dependency Rules
+
+- SDKs do not depend on server code, and servers do not depend on SDKs.
+- Protocol dependencies (gRPC/protobuf) may be transitive. Non-protocol dependencies (e.g., OAuth libraries) should be optional unless the package is explicitly branded for that integration.
+- Exception: google-auth-* libraries for gRPC authentication should be included transitively.

--- a/docs/api-contracts-guidelines.md
+++ b/docs/api-contracts-guidelines.md
@@ -97,11 +97,9 @@ Resource types are configured via a directory structure under `data/schema/resou
 - Role bindings require three tuples in a single `CreateTuples` call: binding->granted->role, binding->subject->principal, workspace->user_grant->binding.
 - Binding IDs follow the deterministic pattern `{role}--{user}--{resource}`.
 
-## Code Example and Documentation Conventions
+## API-Specific Code Example Conventions
 
-For SDK package documentation patterns, code example structure, and region markers, see the [Code Examples](../AGENTS.md#code-examples) and [Client Package Documentation System](../AGENTS.md#client-package-documentation-system) sections in AGENTS.md.
-
-Additional API-specific conventions:
+- All SDK examples demonstrate the same scenario with identical resource data across languages.
 - Async messaging examples (Kafka consumers, outbox pattern) use the Go `confluent-kafka-go` library as the reference implementation.
 - SASL authentication with SCRAM-SHA-512 is the standard for Kafka consumers.
 

--- a/docs/database-guidelines.md
+++ b/docs/database-guidelines.md
@@ -1,0 +1,102 @@
+This repository is a **documentation site** (Astro/Starlight) and contains no application code, database connections, migrations, or ORM logic. All database-related content exists as authored documentation guiding service providers on integration patterns with Kessel Inventory. The guidelines below cover how database topics are documented in this repo.
+
+## Repository Context
+
+- The site is built with Astro and the Starlight documentation theme. There is no runtime database.
+- Database patterns are described in Markdown/MDX files under `src/content/docs/`, not implemented in code.
+- The primary database-related documentation lives in:
+  - `src/content/docs/building-with-kessel/how-to/report-resources.mdx` -- Outbox pattern, CDC, Kafka consumer strategies
+  - `src/content/docs/building-with-kessel/archive/kessel-inventory.md` -- Inventory DB schema (ER diagram in Mermaid)
+  - `src/content/docs/building-with-kessel/archive/kafka-event.md` -- CloudEvents schema for DB change events
+  - `src/content/docs/running-kessel/monitoring-kessel/monitoring-data-replication-inventory-api.mdx` -- Monitoring CDC/Outbox KPIs
+
+## Inventory Database Schema Conventions
+
+- Kessel Inventory uses a **SQL database** (PostgreSQL implied by LISTEN/NOTIFY and WAL references).
+- Resource-specific data is stored as **JSON blobs** (`json` or `jsonb` columns), not normalized relational columns.
+- Primary tables: `resources`, `relationships`, `local_to_inventory_id`.
+- Every primary table has a corresponding `_history` table tracking changes with an `operation_type` field (`CREATE`, `UPDATE`, `DELETE`).
+- Resources are identified by a composite key from the reporter: `(local_resource_id, resource_type, reporter_id, reporter_type)` -- never by an internal DB ID in external APIs.
+- The `local_to_inventory_id` table maps reporter identifiers to internal DB IDs.
+- ER diagrams use **Mermaid `erDiagram`** syntax directly in Markdown files.
+- Lifecycle diagrams use **Mermaid `flowchart LR`** syntax.
+
+## Outbox Pattern Documentation
+
+When documenting or updating the outbox pattern, follow these conventions:
+
+- The outbox table schema aligns with the **Debezium Outbox Event Router** structure:
+  ```sql
+  CREATE TABLE outbox (
+      id UUID NOT NULL,
+      aggregatetype VARCHAR(255) NOT NULL,
+      aggregateid VARCHAR(255) NOT NULL,
+      version VARCHAR(255) NOT NULL,
+      operation VARCHAR(255) NOT NULL,
+      payload JSONB,
+      PRIMARY KEY (id)
+  );
+  ```
+- `version` refers to the Kessel API version (e.g., `v1beta2`), not an event sequence number.
+- `operation` refers to the Kessel API method (e.g., `ReportResource`), not a CRUD verb.
+- `payload` must match the `ReportResourceRequest` API call body.
+- Outbox writes must be in the **same transaction** as the business entity write.
+- Pruning strategy: with Debezium reading from PostgreSQL WAL, rows can be deleted in the **same transaction** that created them.
+- If ordering must be preserved beyond WAL, use a **serial primary key** as a secondary ordering mechanism.
+
+## CDC and Debezium Conventions
+
+- **Debezium** is the recommended CDC tool throughout the docs.
+- CDC reads from the PostgreSQL **write-ahead log (WAL)**, not from polling the outbox table.
+- The CDC pipeline is: PostgreSQL WAL -> Debezium connector (Kafka Connect) -> Kafka topic -> Kafka consumer.
+- Debezium runs inside a **Kafka Connect cluster** managed by Streams for Apache Kafka (Red Hat's Kafka distribution).
+- The Kessel team's consumer is written in **Go** using `confluent-kafka-go` and runs as an **in-process thread**.
+
+## Kafka Event Schema Conventions
+
+- Events follow the **CloudEvents v1.0** specification.
+- Event `type` format for resources: `redhat.inventory.resources.<resource_type>.<operation>` where operation is `created`, `updated`, or `deleted`.
+- Event `type` format for relationships: `redhat.inventory.resources_relationship.<relationship_type>.<operation>`.
+- Event `subject` format: `/resources/<resource_type>/<id>` or `/resources-relationships/<relationship_type>/<id>`.
+- Event `data` contains three sub-objects: `metadata`, `reporter_data`, and either `resource_data` or `relationship_data`.
+- The canonical event schema definition lives in the `inventory-api` repo at `data/kafka-event-schema.json`, not in this docs repo.
+
+## Monitoring and Alerting Conventions
+
+When documenting monitoring for database/replication flows:
+
+- Five custom metrics must be tracked: Messages Processed, Message Process Failures, Consumer Errors, Kafka Error Events, Outbox Event Writes.
+- KPIs derived from these: Message Processing Failure Rate, Consumer Error Rate, Kafka Error Rate, Consumer Lag, End-to-End Lag.
+- End-to-End Lag = time from outbox table write to consumer commit (not just Kafka consumer lag).
+- Metrics are collected into **Prometheus**, visualized in **Grafana**, alerted via **Alertmanager**.
+- Three metrics sources: librdkafka internal stats (via `statistics.interval.ms`), Streams for Apache Kafka JMX exporter, Kafka Lag Exporter.
+- Alerting must cover both data-plane KPIs and platform metrics (DB disk usage, Kubernetes health).
+
+## Kafka Consumer Guarantees
+
+Documentation for consumer implementations must emphasize three guarantees:
+
+1. **In-order processing** -- messages processed in receive order to prevent update-before-create failures.
+2. **At-least-once processing** -- never skip a message; commit only after confirmed processing.
+3. **Idempotent processing** -- reprocessing a message must not cause side effects or corruption.
+
+- Consumer authentication uses **SASL with SCRAM-SHA-512**.
+- Two retry tiers: operation-level retry (exponential backoff, blocks main loop) and consumer-level retry (recreates entire consumer connection from last committed offset).
+- Rebalance handling: register a `RebalanceCallback` that commits stored offsets before partitions are revoked.
+
+## Postgres LISTEN/NOTIFY Pattern
+
+- Used for **immediate write visibility** over async messaging when synchronous confirmation is needed.
+- Flow: request handler writes to outbox + LISTENs on a channel; consumer processes event + NOTIFYs the same channel.
+- Channel names are stable strings (e.g., `host-replication`), not ephemeral per-request channels.
+- LISTEN/NOTIFY must use a **dedicated pg connection**, separate from application logic connections.
+- Payloads use a UUID to correlate the notification back to the originating request/event.
+- Document that channels are **not durable** -- listening must start before the event is produced.
+
+## Documentation Authoring Rules
+
+- SQL examples use PostgreSQL syntax exclusively.
+- Code examples for consumer logic use **Go** (matching the Kessel team's implementation).
+- Database diagrams use **Mermaid** syntax embedded directly in `.md`/`.mdx` files.
+- Archived documentation lives in `src/content/docs/building-with-kessel/archive/` and should not be treated as current guidance.
+- Cross-references to internal Red Hat guides must note the VPN requirement.

--- a/docs/error-handling-guidelines.md
+++ b/docs/error-handling-guidelines.md
@@ -101,7 +101,7 @@ Python TLS examples should let file I/O errors propagate naturally (no explicit 
 
 ### Example code regions
 
-All example files use region markers (`//#region`, `//endregion`, `# region`, `# endregion`) to enable selective inclusion in documentation via `import.meta.glob`. Error handling code MUST be inside the appropriate region so it is included when the documentation renders the example.
+All example files use region markers (`//#region`, `//#endregion`, `# region`, `# endregion`) to enable selective inclusion in documentation via `import.meta.glob`. Error handling code MUST be inside the appropriate region so it is included when the documentation renders the example.
 
 ## Consistency and Failure Patterns in Documentation
 

--- a/docs/error-handling-guidelines.md
+++ b/docs/error-handling-guidelines.md
@@ -1,0 +1,113 @@
+This repository is a documentation site for Project Kessel built with Astro/Starlight. It contains documentation content (`.md`/`.mdx`), example code in multiple languages (Go, Python, Java, TypeScript, Ruby), and Astro components. The error-handling domain here covers two areas: (1) the error-handling patterns documented and exemplified for Kessel SDK consumers, and (2) the documentation site's own build/config concerns.
+
+---
+
+## Scope
+
+This is a documentation repository (Astro/Starlight), not an application runtime. Error-handling guidelines apply to:
+- Example code shipped in `src/examples/` that demonstrates SDK usage to consumers
+- Documentation content describing error handling, retry, and monitoring patterns for Kessel integrators
+- The documentation site build itself (Astro components, config, TypeScript schemas)
+
+## gRPC Error Handling in Example Code
+
+### Language-specific patterns
+
+Each example in `src/examples/getting-started/` and `src/examples/tls/` should follow the idiomatic error-handling pattern for its language:
+
+- **Go**: Use `status.FromError(err)` to extract gRPC status codes. Switch on `codes.Unavailable`, `codes.PermissionDenied`, etc. Use `log.Fatal` or `log.Fatalf` for unrecoverable errors. Wrap errors with `fmt.Errorf("context: %w", err)`.
+- **Python**: Catch `grpc.RpcError` specifically (not generic `Exception`). Log both `e.code()` and `e.details()`.
+- **Java**: Catch `io.grpc.StatusRuntimeException`. Do not catch generic `Exception` for gRPC errors.
+- **TypeScript/JavaScript**: Use generic `catch (error)` blocks (gRPC-js does not expose a typed error class).
+- **Ruby**: Use `rescue => e` blocks and print both the error class and message.
+
+### Do NOT wrap gRPC exceptions
+
+Per the client SDK specification (`src/content/docs/contributing/client-libraries.mdx`):
+- Client SDKs SHOULD define their own top-level error type only for errors NOT thrown by gRPC
+- gRPC exceptions SHOULD NOT be wrapped by the SDK
+
+### Client-side retry, deadlines, and load balancing
+
+Per the client SDK specification:
+- Deadlines, retries, load balancing, and other network-level behavior MUST NOT be specified by client SDK defaults
+- These MUST be defined by the server and discovered by the client through [gRPC service config](https://github.com/grpc/proposal/blob/master/A2-service-configs-in-dns.md)
+- Exception: HTTP/2 Keepalive MAY be configured on the client since it is not available through service config
+
+### Connection lifecycle errors
+
+- Go examples should use `defer conn.Close()` and handle the close error (log, do not fatal). Note: Some examples like `src/examples/tls/example.go` use `defer conn.Close()` without explicit error handling for brevity.
+- Python examples should use `with channel:` context manager for cleanup
+- Java examples should call `channel.shutdown()` in a `finally` block
+
+## Kafka Consumer Retry Patterns
+
+When documenting or modifying Kafka consumer retry logic (as in `src/content/docs/building-with-kessel/how-to/report-resources.mdx`):
+
+### Two-tier retry strategy
+
+1. **Operation-level retry**: Synchronous, blocking retry with exponential backoff for transient failures within a single message processing operation. Configured via `RetryOptions.OperationMaxRetries`. Uses `time.Sleep(backoff)` to block the processing loop. Setting max retries to `-1` means infinite retries.
+
+2. **Consumer-level retry**: Recreates the entire consumer connection when the consume loop encounters `consumer.ErrClosed`. Configured via `RetryOptions.ConsumerMaxRetries`. Also supports `-1` for infinite retries. Forces re-read from last committed offset.
+
+### Data integrity guarantees to document
+
+Any consumer documentation MUST reference these three guarantees:
+- Messages processed in order
+- At-least-once processing (never skip/lose a message)
+- Idempotent processing (reprocessing produces the same outcome)
+
+### Rebalance error handling
+
+Consumer implementations must commit stored offsets in the `RebalanceCallback` when `kafka.RevokedPartitions` is received, before partitions are lost.
+
+## Monitoring and Error Metrics
+
+When documenting monitoring (as in `src/content/docs/running-kessel/monitoring-kessel/monitoring-data-replication-inventory-api.mdx`), reference these custom metrics:
+
+| Metric | Type | Purpose |
+|--------|------|---------|
+| Messages Processed | Counter | Track successful event processing |
+| Message Process Failures | Counter | Track processing failures |
+| Consumer Errors | Counter | Track consumer client failures |
+| Kafka Error Events | Counter | Track Kafka broker errors |
+| Outbox Event Writes | Counter | Track outbox writes for end-to-end lag |
+
+KPIs to document: Message Processing Failure Rate, Consumer Error Rate, Kafka Error Rate, Consumer Lag, End-to-End Lag.
+
+## Authentication Error Handling
+
+- OAuth2 token management includes automatic retry on authentication failures (documented in `src/content/docs/building-with-kessel/how-to/authenticate-with-python-sdk.mdx`)
+- `OAuth2ClientCredentials.getToken()` caches tokens and refreshes when expiry is within 300 seconds
+- `forceRefresh` parameter exists but is documented as "NOT RECOMMENDED"
+- Implementations of `getToken()` must be thread-safe
+
+## TLS Configuration Errors
+
+Go TLS examples should return descriptive wrapped errors:
+```go
+return nil, fmt.Errorf("failed to read the ca cert file: %w", err)
+return nil, fmt.Errorf("failed to add server CA certificate")
+```
+
+Python TLS examples should let file I/O errors propagate naturally (no explicit catch needed for cert loading), but gRPC call errors after TLS setup should catch `grpc.RpcError`.
+
+## Documentation Site Errors
+
+### Astro/TypeScript
+
+- Zod schemas in `src/schemas/client-package.ts` use `.optional().default(false)` for boolean fields -- maintain this pattern for new schema fields
+- The `src/middleware/client-package-toc.ts` middleware augments heading generation; errors here surface as build failures, not runtime errors
+
+### Example code regions
+
+All example files use region markers (`//#region`, `//endregion`, `# region`, `# endregion`) to enable selective inclusion in documentation via `import.meta.glob`. Error handling code MUST be inside the appropriate region so it is included when the documentation renders the example.
+
+## Consistency and Failure Patterns in Documentation
+
+When writing documentation about data replication:
+- Reference the dual-write problem when discussing atomicity between database writes and API/event publishing
+- Reference write skew when discussing concurrent modifications
+- The outbox pattern is the recommended solution for atomic event publishing
+- CDC with Debezium is the recommended tool for change data capture
+- LISTEN/NOTIFY is documented as a pattern for immediate write visibility over async messaging, but with caveats about durability (notifications are not persistent)

--- a/docs/integration-guidelines.md
+++ b/docs/integration-guidelines.md
@@ -1,0 +1,66 @@
+This repository is a **documentation site** (Astro + Starlight) for Project Kessel. It does not contain application code with runtime integrations. Instead, it documents the integration patterns, protocols, and conventions that service providers must follow when integrating with Kessel. The guidelines below cover the documented integration patterns, how they are represented in this repo, and the conventions for writing integration-related documentation.
+
+## Kessel Integration Architecture
+
+- Kessel consists of two core services: **Inventory API** (resource storage and reporting) and **Relations API + SpiceDB** (relationship-based access control). The Relations API is planned to merge into Inventory.
+- The primary protocol is **gRPC** with protobuf. HTTP REST is supported but secondary and may lack features like streaming.
+- API definitions live in external repos and are referenced here. The gRPC spec is on [Buf Schema Registry](https://buf.build/project-kessel/inventory-api), and the OpenAPI spec is pulled from `project-kessel/inventory-api` at build time (see `astro.config.mjs` `starlightOpenAPI` plugin).
+- The current API version is **v1beta2**. References to v1beta1 are deprecated and belong under `archive/`.
+
+## Resource Reporting Patterns
+
+When documenting resource reporting, follow these established patterns:
+
+- **Two reporting methods exist**: synchronous (API/SDK) and asynchronous (Kafka/CDC). Document trade-offs, not just mechanics.
+- Synchronous reporting uses `ReportResourceRequest` via gRPC or SDK. The caller must guarantee atomicity, delivery, and ordering.
+- Async reporting uses Kafka topics owned by Kessel. Document the **outbox pattern** with Debezium CDC as the recommended approach for solving the dual-write problem.
+- The outbox table schema uses columns: `id` (UUID), `aggregatetype`, `aggregateid`, `version` (e.g. `v1beta2`), `operation` (e.g. `ReportResource`), `payload` (JSONB matching the API request body).
+- **Postgres LISTEN/NOTIFY** is documented as a pattern for achieving immediate write visibility over async pipelines. Document that it requires its own connection, uses stable channel names, and payloads must include identifiers for listener filtering.
+
+## CloudEvents Schema
+
+- Kessel Inventory events follow the **CloudEvents v1.0** specification.
+- The event `type` field follows the pattern: `redhat.inventory.resources.{resource_type}.{operation}` where operation is `created`, `updated`, or `deleted`.
+- For relationships: `redhat.inventory.resources_relationship.{relationship_type}.{operation}`.
+- The `subject` field uses: `/resources/{resource_type}/{id}` or `/resources-relationships/{relationship_type}/{id}`.
+- The `data` payload contains three objects: `metadata`, `reporter_data`, and either `resource_data` or `relationship_data`.
+- The canonical event schema reference is at `https://github.com/project-kessel/inventory-api/blob/main/data/kafka-event-schema.json`.
+- Event examples in this repo are in `src/content/docs/building-with-kessel/archive/kafka-event.md`.
+
+## Kafka Consumer Conventions
+
+- Document these three guarantees for consumer implementations: in-order processing, at-least-once delivery, and idempotent processing.
+- Kafka authentication uses **SASL with SCRAM-SHA-512**.
+- Retry logic uses two tiers: operation-level retry (exponential backoff with `time.Sleep`) and consumer-level retry (full consumer recreation on `ErrClosed`).
+- Rebalance handling must commit stored offsets before partition revocation via a `RebalanceCallback`.
+- Consumer deployment options: in-process thread (Kessel team's choice), sidecar container, or standalone pod.
+- Client statistics use `statistics.interval.ms` for health metrics (rtt, rxmsgs).
+- The Kessel team uses `confluent-kafka-go` (Go) and `librdkafka`-based clients.
+
+## SDK Integration Documentation
+
+- SDKs exist for **Go**, **Python**, **TypeScript/JavaScript**, **Ruby**, and **Java**. Repos follow naming `kessel-sdk-{lang}`.
+- SDK import hierarchy: `{prefix}.inventory.v1beta2` for service-specific code, `{prefix}.grpc` for gRPC utilities, `{prefix}.auth` for authentication, `{prefix}.middleware` for transport-agnostic utilities.
+- The `ClientBuilder` pattern is the canonical way to construct clients. Document the builder chain: `ClientBuilder(target).insecure().build()` for dev, `.oauth2ClientAuthenticated(credentials).build()` for prod.
+- `build()` returns a tuple `(Stub, Closeable)` when the stub lacks a `close()` method (Python, Go). In Go: `inventoryClient, conn, err := v1beta2.NewClientBuilder(target).Insecure().Build()`.
+- Authentication uses `OAuth2ClientCredentials` with OIDC discovery or direct token URL. Tokens are cached and auto-refreshed.
+- Code examples are in `src/examples/` organized by topic (e.g. `getting-started/`, `tls/`). They use `#region` / `#endregion` markers for selective rendering via `CodeExamples.astro`.
+
+## Monitoring and Observability
+
+- KPIs for integration health: message processing failure rate, consumer error rate, Kafka error rate, consumer lag, end-to-end lag.
+- Metrics sources: librdkafka internal stats, Streams for Apache Kafka Prometheus JMX Exporter, Kafka Lag Exporter, and custom application metrics.
+- Custom metrics to document: Messages Processed, Message Process Failures, Consumer Errors, Kafka Error Events, Outbox Event Writes.
+- Monitoring stack: Prometheus for aggregation, Grafana for dashboards, Alertmanager for alerts.
+
+## Documentation Conventions for Integration Content
+
+- Place current integration docs under `src/content/docs/building-with-kessel/how-to/` or `concepts/`.
+- Place deprecated API docs (v1beta1) under `archive/` with a deprecation notice at the top.
+- Use `.mdx` extension for docs that need Astro components (Aside, Tabs, Code, LinkCard). Use `.md` for pure markdown.
+- Frontmatter `sidebar.order` controls navigation ordering within sections. Lower numbers appear first.
+- Code examples across multiple languages use `CodeExamples.astro` with glob imports: `import.meta.glob('/src/examples/{topic}/example.*', { query: '?raw', eager: true, import: 'default' })`.
+- Region markers in examples: Go uses `//#region name` and `//#endregion`, Python and Ruby use `# region name` and `# endregion`.
+- When documenting SDK patterns, show examples in at least Go and Python, as these are the most complete reference implementations.
+- Link to Buf Schema Registry for protobuf types rather than duplicating message definitions: `https://buf.build/project-kessel/inventory-api/docs/main:kessel.inventory.v1beta2`.
+- External references to inventory-api OpenAPI schema are configured in `astro.config.mjs` and auto-generate sidebar entries.

--- a/docs/integration-guidelines.md
+++ b/docs/integration-guidelines.md
@@ -48,10 +48,7 @@ When documenting resource reporting, follow these established patterns:
 
 ## Monitoring and Observability
 
-- KPIs for integration health: message processing failure rate, consumer error rate, Kafka error rate, consumer lag, end-to-end lag.
-- Metrics sources: librdkafka internal stats, Streams for Apache Kafka Prometheus JMX Exporter, Kafka Lag Exporter, and custom application metrics.
-- Custom metrics to document: Messages Processed, Message Process Failures, Consumer Errors, Kafka Error Events, Outbox Event Writes.
-- Monitoring stack: Prometheus for aggregation, Grafana for dashboards, Alertmanager for alerts.
+For data replication and consistency monitoring patterns (KPIs, metrics sources, custom metrics), see the [Data Replication and Consistency Monitoring](performance-guidelines.md#data-replication-and-consistency-monitoring) section in performance-guidelines.md.
 
 ## Documentation Conventions for Integration Content
 

--- a/docs/performance-guidelines.md
+++ b/docs/performance-guidelines.md
@@ -1,0 +1,86 @@
+## OAuth2 Token Caching
+
+- `OAuth2ClientCredentials.getToken()` must cache tokens and return the cached token when it does not expire within the next 5 minutes (300 seconds). Only fetch a new token when the cached one is within this expiry window.
+- `getToken()` implementations must be thread-safe across all languages.
+- The `forceRefresh` parameter bypasses the cache. Document it as "NOT RECOMMENDED" and label it with caution in all SDK implementations.
+- Token fetching is lazy -- no network calls until the first `getToken()` invocation. Document this as "Lazy Initialization" in feature lists.
+
+## gRPC Channel and Stub Reuse
+
+- Library documentation and abstractions must guide users to reuse gRPC Channels and Stubs, per [gRPC performance best practices](https://grpc.io/docs/guides/performance/).
+- The `ClientBuilder` may offer a `cacheKey` parameter: if provided, it either creates a new channel/stub or retrieves a cached one using the same key value. Same key assumes same configuration.
+- Channel/stub lifecycle should be managed by the application (e.g. through DI containers). SDK code must not manage global lifecycle silently.
+- `build()` must return a tuple `(Stub, Closeable)` when the stub lacks a `close()` method, ensuring explicit resource cleanup to prevent connection leaks.
+
+## Network Defaults and Service Config
+
+- Deadlines, retries, load balancing, and other network-level behavior must NOT be specified by client defaults. These must be defined by the server and discovered by the client through [gRPC service config](https://github.com/grpc/proposal/blob/master/A2-service-configs-in-dns.md).
+- HTTP/2 Keepalive is an exception -- it requires explicit client-side channel configuration and is not available through service config. The `ClientBuilder` default configuration does NOT include keep alive.
+- The `dns://` URI scheme triggers DNS-based name resolution and service configuration discovery from TXT records. Omitting a scheme defaults to `dns`.
+
+## Python-Specific Performance
+
+- When not using asyncio, Python `ClientBuilder` defaults should enable single-threaded unary streams for improved performance.
+- Provide both `build()` (synchronous) and `buildAsync()` (asyncio) variants. The async variant returns a stub using asyncio channels.
+- Python and Ruby SDKs use native C-based gRPC core. Pre-built binaries are available for Linux (x86_64, ARM64), macOS, and Windows -- installation times are unaffected in normal circumstances.
+
+## gRPC Compilation in CI/CD
+
+- When compiling gRPC from source (Python/Ruby only), limit parallel compilation to prevent CI timeouts caused by double parallelism (package manager + C compiler):
+  - Python: set `GRPC_PYTHON_BUILD_EXT_COMPILER_JOBS=4`
+  - Ruby: set `GRPC_RUBY_BUILD_PROCS=4`, `MAKEFLAGS="-j4"`, and `BUNDLE_JOBS=4`
+- Node.js (`@grpc/grpc-js`), Go (`grpc-go`), and Java (Netty-based) use pure language implementations and never require native compilation.
+- Use glibc-based Docker images (Red Hat UBI or Debian). Alpine (musl) may force source compilation for Python/Ruby.
+- Source compilation is only triggered on unsupported platforms, very new language versions, or explicit flags like `pip install --no-binary :all:`.
+
+## Data Replication and Consistency Monitoring
+
+When documenting data replication patterns (CDC/Outbox), the following KPIs and metrics must be covered:
+
+### Required KPIs
+- **Message Processing Failure Rate**: ratio of processing errors to total processed messages (consumed + committed, not just consumed)
+- **Consumer Error Rate**: rate of Kafka consumer client errors affecting broker interaction
+- **Kafka Error Rate**: rate of Kafka broker error events
+- **Consumer Lag**: difference between last broker offset and last committed consumer offset
+- **End-to-End Lag**: time gap from outbox table write to consumer processing and commit
+
+### Required Metrics Sources
+- **librdkafka internal metrics**: enable via `statistics.interval.ms` (e.g. 60000) on the Kafka consumer client; captures rtt, rxmsgs, and client health
+- **Kafka Connect metrics**: Prometheus JMX Exporter on the Debezium connector for CDC health
+- **Kafka Lag Exporter**: supplemental offset/lag data from Streams for Apache Kafka
+- **Custom application metrics** (Prometheus counters): `messages_processed`, `message_process_failures`, `consumer_errors`, `kafka_error_events`, `outbox_event_writes`
+
+### Alerting
+- Alerts must directly align with the KPIs above, plus platform metrics (database disk usage, Kubernetes health).
+
+## Kafka Consumer Performance Patterns
+
+- Use **ordered, sequential processing** -- messages must be processed in order within a partition. Do not parallelize message processing within a single partition.
+- Use **operation-level retry with exponential backoff** (`time.Sleep` blocking) for transient failures. This intentionally blocks the consumer loop to preserve ordering.
+- Use **consumer-level retry** (recreate the entire consumer connection) for unrecoverable consumer errors (`ErrClosed`), forcing re-read from last committed offset.
+- Register a `RebalanceCallback` to commit stored offsets before partitions are revoked, preventing duplicate processing on rebalance.
+- Kessel runs the consumer as an **in-process thread** within the main application. Document the trade-off: simple deployment but tightly coupled resources (CPU/memory contention). Alternatives are sidecar container or standalone pod.
+
+## Outbox Table Performance
+
+- Prune the outbox table immediately -- with Debezium reading from the write-ahead log, delete outbox rows within the same transaction that created them.
+- Track outbox event creation rate alongside consumption rate to detect end-to-end lag buildup.
+- Guard against write skew in concurrent read-modify-write cycles on the outbox table.
+
+## Immediate Visibility with Async Messaging
+
+- Use PostgreSQL `LISTEN`/`NOTIFY` to bridge async event processing with synchronous request handling when immediate write visibility is required.
+- `LISTEN` must use its own dedicated connection, separate from application logic connections, to avoid blocking.
+- Minimize connection creation -- reuse connections for `LISTEN` rather than creating per-request connections.
+- Use consistent channel names (not ephemeral) to avoid overhead of frequent channel creation/destruction. Distinguish events by payload identifiers, not channel names.
+
+## Streaming and Pagination
+
+- `listWorkspaces` and `listWorkspacesAsync` use streaming responses with a default pagination limit of 1000 items per page.
+- Support `continuationToken` for resuming paginated listings across pages.
+- Provide async iterator variants (`listWorkspacesAsync`) for languages that support it (Python, JavaScript).
+
+## Replication Lag Awareness in Examples
+
+- Code examples for `Check` requests after `ReportResource` must include a comment noting that replication lag may delay permission visibility: `// NOTE: You may need to wait for replication and caches to update.`
+- Do not add artificial delays or retry loops in examples -- just document the caveat.

--- a/docs/security-guidelines.md
+++ b/docs/security-guidelines.md
@@ -1,0 +1,102 @@
+## Authentication
+
+### OAuth 2.0 Client Credentials Flow
+- Kessel uses OAuth 2.0 Client Credentials grant as the primary authentication mechanism for service-to-service communication.
+- The `auth` package in each SDK provides `OAuth2ClientCredentials` class accepting `clientId`, `clientSecret`, and `tokenEndpoint`.
+- Two methods to discover the token endpoint: OIDC Discovery via `fetchOIDCDiscovery(issuerUrl)` or a direct token URL.
+- Token caching is built-in: cached tokens are reused until they expire within 5 minutes (300 seconds). Implementations must be thread-safe.
+- `forceRefresh` parameter exists on `getToken()` but is explicitly discouraged ("NOT RECOMMENDED. Force with caution!").
+- The `oAuth2AuthRequest` function wraps `OAuth2ClientCredentials` into an `AuthRequest` interface for injecting tokens into HTTP requests.
+- In Python, prefer native auth constructs (e.g. `requests` library auth) over the generic `AuthRequest` interface.
+
+### Credential Configuration
+- Applications integrating with Kessel should expose these configuration options:
+  - `KESSEL_ENABLED`, `KESSEL_URL`, `KESSEL_AUTH_ENABLED`
+  - `KESSEL_AUTH_CLIENT_ID`, `KESSEL_AUTH_CLIENT_SECRET`, `KESSEL_AUTH_OIDC_ISSUER`
+  - `KESSEL_INSECURE`
+- Client credentials (client ID/secret) should be read from environment variables or secure config, not hardcoded. However, getting-started examples for local development may use inline placeholders to demonstrate the API surface.
+- For OIDC validation in Kessel Inventory, configure the `authn.oidc` section with `authn-server-url`, `client-id`, `skip-client-id-check`, and `insecure-client`.
+
+### Workspace ID Lookups and `x-rh-identity`
+- When resolving workspace IDs from RBAC (`GET /api/rbac/v2/workspaces/?type=root|default`), do NOT relay the `x-rh-identity` header from the original request. The calling service must authenticate with its own OAuth token.
+- Set `x-rh-rbac-org-id` header so RBAC identifies the correct account.
+- This prevents failures when the end-user principal lacks workspace listing permissions.
+
+## Transport Security (TLS)
+
+### Client-side TLS Configuration
+- OAuth 2.0 authentication requires TLS transport credentials; they are not independent.
+- The `ClientBuilder` defaults to runtime-default TLS when no explicit `ChannelCredentials` are provided.
+- For Kubernetes/OpenShift, mount CA certificates via ConfigMaps (e.g. `openshift-service-ca.crt` at `/ca-certs/service-ca.crt`).
+- TLS setup follows a three-step pattern in all SDKs:
+  1. Configure transport credentials (load CA certificate)
+  2. Configure call credentials (OAuth 2.0)
+  3. Combine both via the `ClientBuilder`
+
+### ClientBuilder Security Modes
+- `oauth2ClientAuthenticated(credentials, channelCredentials?)` -- Authenticated with OAuth 2.0 + TLS (production default).
+- `authenticated(callCredentials?, channelCredentials?)` -- Generic authenticated mode.
+- `unauthenticated(channelCredentials?)` -- TLS only, no client auth.
+- `insecure()` -- No TLS, no auth. Only for local development and testing.
+
+## Authorization Model (SpiceDB / Relationship-Based Access Control)
+
+### Permission Schema (KSL Language)
+- Permissions are defined in `.ksl` files using the KSL schema language, compiled to SpiceDB `.zed` schema via the `ksl` compiler.
+- The RBAC model has five core types in the `rbac` namespace: `principal`, `group`, `role`, `role_binding`, `workspace`.
+- Permissions flow through workspace hierarchy: `workspace -> role_binding -> role -> permission`. Workspaces support parent-child relationships for inheritance.
+- Use `@rbac.add_permission(name:'permission_name')` extension to add permissions that propagate through role, role_binding, and workspace types.
+
+### V1-to-V2 Migration Extensions
+- `@rbac.add_v1_based_permission(app, resource, verb, v2_perm)` converts legacy RBACv1 permissions to Kessel, automatically generating wildcard permutations (`_all_` variants).
+- Naming convention for v2 permissions: `read` becomes `view`, `write` becomes `edit`.
+- `@rbac.add_contingent_permission(first, second, contingent)` creates compound permissions that require both conditions (e.g. `inventory_host_view AND patch_system_view_assigned`).
+- Use the `_assigned` suffix for intermediate compound permissions; the contingent permission (without suffix) is what access checks should use.
+- Schema files are stored per-environment in `rbac-config` repo (`configs/stage/schemas/src`, `configs/prod/...`).
+
+### Check vs CheckForUpdate
+- Use `Check` for standard read operations.
+- Use `CheckForUpdate` for write operations and highly-sensitive read operations (e.g. reading credentials for connecting to a customer cluster). This provides stronger consistency guarantees.
+
+### Constructing Authorization Requests
+- Subject references for users follow the pattern: `resourceType: "principal"`, `resourceId: "redhat/{principalID}"`, `reporter.type: "rbac"`.
+- `principalID` differs by principal type: `identity.User.UserId` for users, `identity.ServiceAccount.UserId` for service accounts.
+- Workspace resources use `resourceType: "workspace"`, `reporter.type: "rbac"`.
+- The `rbac.v2` SDK package provides convenience functions: `principalResource(id, domain)`, `principalSubject(id, domain)`, `workspaceResource(id)`, `roleResource(id)`, `subject(resourceRef, relation?)`.
+
+### Role Bindings
+- A role binding requires three relationship tuples created atomically:
+  1. `role_binding -> granted -> role`
+  2. `role_binding -> subject -> principal`
+  3. `workspace -> user_grant -> role_binding`
+- Use deterministic binding IDs derived from inputs (e.g. `{roleName}--{userId}--{resourceId}`).
+
+## gRPC Security Conventions
+
+### Package Isolation
+- The `grpc` package must NOT import from peer packages (`auth`, `http`, `middleware`).
+- `oauth2CallCredentials(credentials)` creates gRPC `CallCredentials` from `OAuth2ClientCredentials`, following the same patterns as `google-auth-*` libraries.
+- Authentication middleware dependencies (e.g. `google-auth-*` libraries) may be included transitively as they are designed as library dependencies.
+- Optional auth dependencies should NOT be pulled in transitively; use optional install extras (e.g. `pip install "kessel-sdk[auth]"` for Python).
+
+### Network Configuration
+- Deadlines, retries, load balancing must NOT be set by client defaults. They are discovered from the server via gRPC service config.
+- HTTP/2 Keepalive is the exception and may be configured client-side.
+- Channels and stubs should be reused per gRPC performance best practices to avoid creating new connections per request.
+
+## Kafka Authentication
+- For secured Kafka clusters, use SASL with SCRAM-SHA-512 mechanism.
+- Required consumer configuration properties: `security-protocol: sasl_plaintext`, `sasl-mechanism: SCRAM-SHA-512`, `sasl-username`, `sasl-password`.
+
+## Ephemeral Environment Authentication Setup
+- Create service accounts via Stage IAM (`console.stage.redhat.com/iam/service-accounts`).
+- Extract the `sub` claim from the JWT to configure system-level access in RBAC.
+- Grant service account admin access by creating a `system-users` Kubernetes secret with the `sub` as key and `admin: true`, `is_service_account: true`, `allow_any_org: true`.
+- Reconfigure RBAC to validate tokens against Stage SSO by setting `IT_BYPASS_TOKEN_VALIDATION=False` and `IT_SERVICE_HOST=sso.stage.redhat.com`.
+- Kessel Inventory OIDC config points to `https://sso.stage.redhat.com/auth/realms/redhat-external`.
+
+## Documentation Security Rules
+- Avoid including real credentials, secrets, or tokens in documentation or example code. Use placeholders like `"your-client-id"`, `<PASSWORD>`, or environment variable references.
+- Getting-started example code for local development uses `insecure()` mode with a clear comment indicating it is for local development only.
+- TLS examples should demonstrate loading CA certificates, not disabling TLS verification.
+- Internal documentation requiring authentication is served at separate URLs with GitHub org membership or VPN auth.

--- a/docs/sources.yaml
+++ b/docs/sources.yaml
@@ -1,0 +1,93 @@
+# Documentation Sources
+#
+# This file lists the source code repositories and other sources of truth that are relevant
+# for documentation generation. AI agents (like the doc-gaps skill) use this to discover
+# what to analyze when generating or updating documentation.
+#
+# AI Agent Instructions:
+# - To locate repositories locally, search common patterns:
+#   1. Check parent directory: ../repository-name/
+#   2. Check grandparent: ../../repository-name/
+#   3. Search for repository name in common locations
+# - If not found locally, ask the user for the path or offer to clone from GitHub
+
+repositories:
+  - name: inventory-api
+    type: api
+    github: https://github.com/project-kessel/inventory-api
+    description: Kessel Inventory API - main service for resource reporting and authorization
+    technologies:
+      - Go
+      - gRPC
+      - PostgreSQL
+      - Kafka
+
+  - name: relations-api
+    type: api
+    github: https://github.com/project-kessel/relations-api
+    description: Relations API - wrapper around SpiceDB for authorization
+    technologies:
+      - Go
+      - gRPC
+      - SpiceDB
+
+  - name: kessel-sdk-go
+    type: sdk
+    github: https://github.com/project-kessel/kessel-sdk-go
+    description: Go SDK for Kessel clients
+    technologies:
+      - Go
+      - gRPC
+
+  - name: kessel-sdk-py
+    type: sdk
+    github: https://github.com/project-kessel/kessel-sdk-py
+    description: Python SDK for Kessel clients
+    technologies:
+      - Python
+      - gRPC
+
+  - name: kessel-sdk-ruby
+    type: sdk
+    github: https://github.com/project-kessel/kessel-sdk-ruby
+    description: Ruby SDK for Kessel clients
+    technologies:
+      - Ruby
+      - gRPC
+
+  - name: kessel-sdk-node
+    type: sdk
+    github: https://github.com/project-kessel/kessel-sdk-node
+    description: Node.js/TypeScript SDK for Kessel clients
+    technologies:
+      - TypeScript
+      - gRPC
+
+  - name: kessel-sdk-java
+    type: sdk
+    github: https://github.com/project-kessel/kessel-sdk-java
+    description: Java SDK for Kessel clients
+    technologies:
+      - Java
+      - gRPC
+
+  - name: ksl-schema-language
+    type: schema
+    github: https://github.com/project-kessel/ksl-schema-language
+    description: Kessel Schema Language (KSL) compiler
+    technologies:
+      - TypeScript
+
+  - name: insights-rbac
+    type: service
+    github: https://github.com/RedHatInsights/insights-rbac
+    description: RBAC service provider for workspaces, users, roles, groups, and role bindings (Insights/Kessel hybrid)
+    technologies:
+      - Python
+      - Django
+      - PostgreSQL
+
+# Usage notes:
+# - Add new repositories here when they become relevant for documentation
+# - Remove or comment out repositories that are no longer maintained
+# - The file is version-controlled and portable across different development setups


### PR DESCRIPTION
Implements a layered documentation system for AI-assisted development:

- Domain guidelines (docs/*-guidelines.md): Detailed, domain-specific playbooks for security, performance, error-handling, API contracts, database, and integration patterns
- AGENTS.md: Agent onboarding doc with cross-cutting conventions and docs index (agent-agnostic)
- CLAUDE.md: Claude Code-specific layer importing AGENTS.md with build/test commands
- .coderabbit.yaml: Points CodeRabbit to guideline files for PR review
- README.md: Enhanced with project overview and documentation links