### PR TITLE
RHCLOUD-47238 Add comprehensive concept documentation for Kessel core model

### DIFF
--- a/src/content/docs/building-with-kessel/concepts/coming-from-rbac-v1.mdx
+++ b/src/content/docs/building-with-kessel/concepts/coming-from-rbac-v1.mdx
@@ -1,5 +1,337 @@
 ---
 title: Coming from RBAC v1
+description: Understand the conceptual differences between legacy RBAC (v1) and Kessel-based RBAC (v2), including workspace scoping, permission inheritance, and the authorization graph model.
 sidebar:
   order: 90
 ---
+
+import { Aside, LinkCard } from '@astrojs/starlight/components';
+
+If you're familiar with Red Hat Insights RBAC v1 (the legacy RBAC system), Kessel-based RBAC v2 introduces several new concepts and changes how authorization works. This document explains the key conceptual shifts to help you understand how familiar RBAC v1 patterns map to the new model.
+
+<Aside type="note">
+  This is a conceptual overview, not a migration guide. For step-by-step migration instructions, see [Migrate from RBAC v1 to RBAC v2](/docs/building-with-kessel/how-to/migrate-from-rbac-v1-to-v2/).
+</Aside>
+
+## Core Conceptual Shifts
+
+RBAC v2 introduces four fundamental changes to how authorization works:
+
+**1. Workspace-Based Scoping** — Permissions are no longer just organization-wide. They can be scoped to specific workspaces (organizational units), with a hierarchy that enables permission inheritance.
+
+**2. Native Wildcard Permissions** — Wildcard permissions (`config_manager:*:read`) are evaluated server-side by Kessel, not by your application code.
+
+**3. Graph-Based Authorization** — Permission checks traverse a relationship graph rather than simple permission list matching. This enables complex patterns like "users who can view a parent workspace can view child workspaces."
+
+**4. Everything is a Resource** — Users, groups, workspaces, roles, and your application's resources (hosts, policies, etc.) are all modeled uniformly as resources with relationships.
+
+The rest of this document explains each shift in detail.
+
+## Permissions: Format and Transformation
+
+### Permission Format (Transformed for Kessel)
+
+**RBAC v1 and v2 both use the three-part format:**
+
+```
+application:resource_type:operation
+```
+
+**Examples:**
+- `config_manager:profile:read`
+- `patch:system:write`
+- `advisor:recommendation_results:*`
+
+**However, in RBAC v2, these are transformed when written to Kessel:**
+
+1. **Colons become underscores**: `config_manager:profile:read` → `config_manager_profile_read`
+2. **Operation names change** to avoid v1/v2 collision:
+   - `read` → `view`
+   - `write` → `edit`
+3. **Final permission name**: `config_manager_profile_view`
+
+**What this means:**
+
+When you check permissions with Kessel, you use the transformed name (`config_manager_profile_view`), not the RBAC v1 format. The schema handles this transformation automatically using the `@rbac.add_v1_based_permission()` extension.
+
+<Aside>
+  The naming change (`read` → `view`, `write` → `edit`) distinguishes v2 permissions from legacy v1 permissions and prevents collisions in the authorization schema.
+</Aside>
+
+### Wildcard Permissions (Query for Specific Permission Only)
+
+**RBAC v1:**
+
+In the legacy system, wildcard permissions like `config_manager:*:read` were stored as strings. Your application code had to test all possible wildcard variations:
+
+```python
+# RBAC v1: Client-side wildcard logic
+def has_permission(user_permissions, required_permission):
+    # Must check exact match AND all wildcard variations
+    for perm in user_permissions:
+        if matches_wildcard(perm, required_permission):
+            return True
+    return False
+```
+
+To check if a user had `config_manager:profile:read`, you had to test all variations:
+- `config_manager:profile:read` (exact match)
+- `config_manager:profile:*` (wildcard operation)
+- `config_manager:*:read` (wildcard resource type)
+- `config_manager:*:*` (wildcard both)
+- `*:*:*` (global wildcard)
+
+Your code had to implement this matching logic.
+
+**RBAC v2:**
+
+You only query for the specific permission you need (using the transformed v2 name). Kessel handles all wildcard matching server-side.
+
+```python
+# RBAC v2: Just check the specific permission (transformed name)
+result = kessel_client.check(
+    resource=workspace,
+    permission="config_manager_profile_view",  # Transformed: read → view
+    subject=user
+)
+```
+
+Kessel automatically checks all applicable wildcard permissions (`config_manager_profile_all`, `config_manager_all_view`, etc.) and returns the result.
+
+**What this means:**
+
+- **Services query for specific permissions only** — No need to test all wildcard variations in your code
+- **Consistent behavior** — All applications get the same wildcard semantics
+- **Simpler code** — One check instead of multiple wildcard tests
+
+## Workspace Hierarchy and Scoping
+
+This is the biggest conceptual shift in RBAC v2.
+
+### RBAC v1: Organization-Wide or Inventory Groups
+
+**RBAC v1** had two scoping models:
+
+**Organization-wide permissions:**
+- Permissions applied to the entire organization
+- Example: A user with `config_manager:profile:read` could read all profiles in the org
+
+**Inventory group filtering (host-specific):**
+- Some permissions used inventory groups (RBAC v1 inventory groups, not RBAC v2 workspaces) to filter access to hosts
+- Example: `inventory:hosts:read` with group filter `["prod-servers"]`
+- Application code had to query RBAC for the user's allowed groups and filter data accordingly
+
+### RBAC v2: Workspace Hierarchy
+
+**RBAC v2** introduces **workspaces** — organizational units arranged in a tree structure:
+
+```mermaid
+graph TD
+    Root["ROOT workspace<br/>(organization)"]
+    
+    Root --> Engineering["Engineering workspace"]
+    Root --> Operations["Operations workspace"]
+    
+    Engineering --> Frontend["Frontend Team workspace"]
+    Engineering --> Backend["Backend Team workspace"]
+    
+    Operations --> Production["Production workspace"]
+    Operations --> Staging["Staging workspace"]
+```
+
+**Key concepts:**
+
+**Workspace assignment:**
+- Resources (hosts, policies, documents, etc.) are assigned to a workspace
+- This is done by setting `workspace_id` in the resource representation
+
+**Role bindings on workspaces:**
+- Instead of granting permissions organization-wide, you grant roles on specific workspaces
+- Example: Grant "Inventory Viewer" role to Alice on the "Engineering" workspace
+
+**Permission inheritance:**
+- Role bindings on parent workspaces grant access to child workspaces
+- If Alice has "Inventory Viewer" on "Engineering", she can view resources in "Frontend Team" and "Backend Team"
+- This happens automatically — no special handling needed
+
+**What this means:**
+
+- **Scoped access by default** — Most permissions are workspace-scoped
+- **Hierarchical delegation** — Admins at higher levels automatically have access to lower levels
+- **Simpler group management** — Workspaces replace complex inventory group filters
+
+<Aside>
+  In RBAC v1, you filtered hosts by inventory groups in your application code. In RBAC v2, you query Kessel for the workspaces a user can access, then filter resources by those workspace assignments.
+</Aside>
+
+<Aside type="caution" title="Explicit workspace assignment in RBAC v2">
+  **RBAC v1** had implicit inventory group membership depending on how groups were returned — you might be part of groups you didn't explicitly got on the returned response.
+  
+  **RBAC v2** returns only explicit workspaces where you have permissions. When you query Kessel for accessible workspaces, you get exactly the workspaces where you have role bindings (either directly or through group membership). There are no implicit workspace assignments.
+</Aside>
+
+## Authorization Model: Checks vs. Graph Traversal
+
+### RBAC v1: Simple Permission Matching
+
+**RBAC v1** used straightforward permission checking:
+
+1. Fetch user's permissions from RBAC service
+2. Check if the required permission is in the list (handling wildcards)
+3. For inventory groups, additionally check if the resource's group is allowed
+
+```python
+# RBAC v1 pattern
+user_permissions = rbac_client.get_user_permissions(user_id)
+if required_permission in user_permissions:
+    allow_access()
+```
+
+### RBAC v2: Relationship Graph Traversal
+
+**RBAC v2** models authorization as a graph of relationships:
+
+```mermaid
+graph LR
+    Alice[Alice] -->|member of| Group[Engineering Group]
+    Group -->|subject of| Binding[Role Binding]
+    Binding -->|grants| Role[Inventory Viewer]
+    Binding -->|on| Workspace[Engineering Workspace]
+    Resource[Host: server-123] -->|assigned to| Workspace
+    
+    style Alice fill:#e1f5ff
+    style Resource fill:#fff4e1
+```
+
+When you call `Check` to ask "Can Alice view this host?", Kessel:
+1. Finds the host's workspace assignment
+2. Walks up the workspace hierarchy
+3. Checks if Alice (or her groups) has a role binding at any level
+4. Verifies the role includes the requested permission
+5. Returns allowed/denied
+
+**What this means:**
+
+- **No permission lists in responses** — You don't fetch a user's permissions; you ask "can they do this specific thing?"
+- **Context-aware** — The same user might have different permissions on different workspaces
+- **Complex patterns supported** — Inheritance, group membership, and role composition happen automatically
+
+## Role Bindings: Where Permissions Are Granted
+
+### RBAC v1: Roles Assigned to Users/Groups
+
+**RBAC v1:**
+
+Roles were assigned directly to users or groups at the organization level:
+- Create a role with permissions
+- Assign the role to a user or group
+- The user gets those permissions organization-wide (unless filtered by inventory groups)
+
+### RBAC v2: Role Bindings on Resources
+
+**RBAC v2:**
+
+Roles are bound to subjects (users/groups) **on specific resources** (workspaces or tenants):
+
+**Role binding structure:**
+- **Role** — The role being granted (e.g., "Inventory Viewer")
+- **Subject** — Who gets the role (a group or user)
+- **Resource** — Where the role applies (a workspace or tenant)
+
+**Example:**
+
+"Grant the Inventory Viewer role to the Engineering Group on the Engineering workspace"
+
+```json
+{
+  "role": "inventory-viewer-role-uuid",
+  "subject": {
+    "type": "group",
+    "id": "engineering-group-uuid"
+  },
+  "resource": {
+    "type": "workspace",
+    "id": "engineering-workspace-uuid"
+  }
+}
+```
+
+**What this means:**
+
+- **Scoped grants** — Roles apply to specific workspaces, not the entire organization
+- **Multiple bindings** — The same role can be granted to different groups on different workspaces
+- **Workspace inheritance** — A binding on a parent workspace grants access to child workspaces
+
+## What Stays the Same
+
+Not everything changed. These concepts are familiar from RBAC v1:
+
+**Groups:**
+- Groups are still collections of users
+- Users can belong to multiple groups
+- Role bindings target groups (recommended) or individual users
+
+**Roles:**
+- Roles are still named collections of permissions
+- Custom roles can be created by organization admins
+- Seeded roles are provided by the system
+
+**Permissions:**
+- Still use the `application:resource_type:operation` format
+- Wildcards are supported (but evaluated differently)
+
+**Permission checks:**
+- You still check "does this user have this permission?" before allowing an action
+- The mechanics changed (graph traversal vs. list matching) but the concept is the same
+
+## Common Migration Patterns
+
+When migrating from RBAC v1 to v2, most use cases fall into these patterns:
+
+**Default workspace pattern:**
+- Resources that aren't explicitly workspace-aware yet
+- Assign all resources to the organization's default workspace
+- Role bindings on default workspace grant access organization-wide (like RBAC v1 behavior)
+
+**Root workspace pattern:**
+- Organization-wide settings or permissions
+- Check permissions on the ROOT workspace
+- Maintains organization-level access control
+
+**Workspace-level list pattern:**
+- Resources that are workspace-aware (especially host-centric assets)
+- Query Kessel for workspaces the user can access
+- Filter application data by those workspace IDs
+- Replaces inventory group filtering
+
+**Organization-level pattern:**
+- Permissions that truly apply organization-wide and should never be workspace-scoped
+- Bound to the tenant resource, not workspaces
+
+See the [migration guide](/building-with-kessel/how-to/migrate-from-rbac-v1-to-v2/) for detailed implementation examples.
+
+## Next Steps
+
+<LinkCard
+  title="Migrate from RBAC v1 to RBAC v2"
+  description="Step-by-step guide for migrating from legacy RBAC to Kessel-based RBAC."
+  href="/docs/building-with-kessel/how-to/migrate-from-rbac-v1-to-v2/"
+/>
+
+<LinkCard
+  title="Role-based access control"
+  description="Understand the RBAC v2 model in depth: roles, permissions, role bindings, and groups."
+  href="/docs/building-with-kessel/concepts/rbac/"
+/>
+
+<LinkCard
+  title="Identity and multi-tenancy"
+  description="Learn about workspaces, workspace hierarchy, and tenant isolation."
+  href="/docs/building-with-kessel/concepts/tenancy/"
+/>
+
+<LinkCard
+  title="Relationships and permissions"
+  description="Understand the authorization graph and how permission checks work."
+  href="/docs/building-with-kessel/concepts/relationships-permissions/"
+/>

--- a/src/content/docs/building-with-kessel/concepts/relationships-permissions.mdx
+++ b/src/content/docs/building-with-kessel/concepts/relationships-permissions.mdx
@@ -1,5 +1,322 @@
 ---
 title: Relationships and permissions
+description: Understand how Kessel models relationships between resources, subjects, and permissions using an authorization graph.
 sidebar:
   order: 20
 ---
+
+import { Aside, LinkCard } from '@astrojs/starlight/components';
+
+Kessel's authorization system is built on a graph of **relationships** between resources. When you create a role binding, add a user to a group, or assign a resource to a workspace, you're creating relationships that Kessel uses to evaluate permissions. This document explains the core concepts behind relationships: what they are, how they're defined, and how Kessel uses them to answer authorization questions.
+
+Understanding relationships helps you reason about how permissions work in Kessel and how your resource reports and configuration affect access control.
+
+## Core Concepts
+
+### Resources and Subjects
+
+All entities in Kessel—users, groups, workspaces, hosts, roles—are modeled as **resources**. A resource is any addressable object with a type and an identifier.
+
+**Examples:**
+- `user:alice` — A user resource
+- `group:engineering` — A group resource  
+- `workspace:eng-prod` — A workspace resource
+- `doc:readme` — A document resource
+
+When describing a relationship, we use two relative terms:
+
+- **Object** — The resource being accessed, or the container (e.g., the group, the document, the workspace)
+- **Subject** — The entity that has the relation or is performing the action (e.g., the user, another group)
+
+**Example:** "Alice is a member of the Engineering group"
+
+- Object: `group:engineering` (the group being accessed)
+- Relation: `member` (the type of connection)
+- Subject: `user:alice` (the person who is a member)
+
+You can read this as: "The Engineering group has Alice as a member" or "Alice has the member relation to the Engineering group."
+
+### Relations
+
+A **relation** is a named string that defines the *type* of connection between an object and a subject.
+
+**Common relations:**
+- `member` — Membership in a group
+- `viewer` — Permission to view a resource
+- `owner` — Ownership of a resource
+- `parent` — Hierarchical parent-child relationship
+- `workspace` — Resource assignment to a workspace
+
+Relations are **directional**. Reversing the object and subject produces a different relation. Convention is to state the object first, then the subject: "group:engineering has member user:alice."
+
+### Relationships
+
+A **relationship** is the realization of a relation between an object and a subject. It's a connection in the authorization graph.
+
+**Example relationships:**
+- Alice is a member of `group:engineering`
+- Alice can view `doc:readme`
+- `workspace:prod` has parent `workspace:root`
+
+Relationships are what Kessel evaluates when answering authorization questions like "Can Alice view this document?" or "What workspaces can Bob access?"
+
+### Subject Sets
+
+Instead of connecting to a specific subject, a relationship can point to a **subject set**—the set of all resources that share a particular relation on another object.
+
+**Example:**
+- All members of `group:engineering` can view `doc:readme`
+
+This is how group-based permissions work: instead of creating individual relationships for each user, you create one relationship to a subject set (all members of the Engineering group). As group membership changes, the effective relationships update automatically.
+
+A single relationship to a subject set can represent **zero-to-many** actual relationships depending on how many subjects are in the set.
+
+<Aside>
+  Subject sets are the mechanism behind workspace hierarchy permission inheritance. When you grant permissions on a parent workspace, you're granting them to the subject set "all users with access to any child workspace."
+</Aside>
+
+## How Relationships Are Defined
+
+Here's the critical distinction: **not all relationships are stored directly**. Some relationships exist because you explicitly created them, while others are computed from rules that combine simpler facts.
+
+### Stored Relationships
+
+You create relationships by reporting resources, creating role bindings, or managing access through the API.
+
+**Examples of stored relationships:**
+- When you add Alice to the Engineering group, Kessel stores: Alice is a member of `group:engineering`
+- When you assign a document to a workspace, Kessel stores: `doc:readme` belongs to `workspace:prod`
+- When you create a role binding, Kessel stores the binding's relationships
+
+These stored relationships are what you manage through the API (via `ReportResource`, creating role bindings, etc.). They're the persistent, explicit facts that Kessel stores.
+
+### Relationship Rules: Computed Relationships
+
+Kessel can compute relationships based on other relationships. There are three ways this happens:
+
+#### 1. Direct: Use Stored Facts
+
+If there's a stored relationship, it exists.
+
+**Example:**
+
+If there's a stored relationship "Alice is a member of Engineering," then the relationship exists: Alice has `member` relation to that group.
+
+```mermaid
+graph LR
+    Alice[Alice] -->|member| Engineering[group:engineering]
+    
+    style Alice fill:#e1f5ff
+    style Engineering fill:#fff4e1
+```
+
+The relationship exists because it's explicitly stored.
+
+#### 2. Inheritance: Follow Links
+
+Relationships can inherit from related resources.
+
+**Example:**
+
+If Alice can view a folder, she can automatically view all documents inside that folder.
+
+```mermaid
+graph LR
+    Alice[Alice] -->|viewer| Folder[folder:docs]
+    Document[doc:readme] -->|parent| Folder
+    Alice -.->|viewer<br/><i>computed</i>| Document
+    
+    style Alice fill:#e1f5ff
+    style Folder fill:#fff4e1
+    style Document fill:#fff4e1
+```
+
+**How this works:**
+1. Alice can view `folder:docs` (stored relationship)
+2. `doc:readme` has parent `folder:docs` (stored relationship)
+3. The document has a rule: *"viewers of my parent can view me"*
+4. Kessel computes: Alice can view the document
+
+This is how workspace permissions work: if you have access to a parent workspace, you inherit access to all child workspaces.
+
+#### 3. Combination: Mix Multiple Rules
+
+Relationships can combine multiple sources.
+
+**OR (either one works):**
+
+You can view a document if you're a viewer OR an owner.
+
+```mermaid
+graph LR
+    Alice[Alice] -->|viewer| Document[doc:readme]
+    Bob[Bob] -->|owner| Document
+    Alice -.->|can view<br/><i>via viewer</i>| Access[Access Granted]
+    Bob -.->|can view<br/><i>via owner</i>| Access
+    
+    style Alice fill:#e1f5ff
+    style Bob fill:#e1f5ff
+    style Document fill:#fff4e1
+    style Access fill:#e8f5e9
+```
+
+The document has a rule: *"viewer OR owner can view me"* — either relationship grants access.
+
+**AND (need both):**
+
+You can delete a document only if you're an owner AND approved.
+
+**EXCEPT (exclude some):**
+
+All viewers can access a document, except suspended users.
+
+### Putting It Together
+
+Here's a realistic example using all three types:
+
+**Who can view a document?**
+
+A user can view a document if:
+- They were explicitly granted viewer access (direct), OR
+- They own the document (combination), OR  
+- They can view the document's parent folder (inheritance)
+
+```mermaid
+graph TB
+    Alice[Alice] -->|viewer| Folder[folder:docs]
+    Document[doc:readme] -->|parent| Folder
+    Document -->|owner| Bob[Bob]
+    
+    Alice -.->|can view<br/><i>via inheritance</i>| Result[Both can view doc:readme]
+    Bob -.->|can view<br/><i>via ownership</i>| Result
+    
+    style Alice fill:#e1f5ff
+    style Bob fill:#e1f5ff
+    style Folder fill:#fff4e1
+    style Document fill:#fff4e1
+    style Result fill:#e8f5e9
+```
+
+**Stored facts** (solid lines):
+- `doc:readme` has parent `folder:docs`
+- `doc:readme` has owner Bob
+- Alice can view `folder:docs`
+
+**Computed results** (dotted lines):
+- Bob can view readme (because he's the owner — combination rule)
+- Alice can view readme (because she can view the parent folder — inheritance rule)
+
+## Stored vs. Computed Relationships
+
+Understanding this distinction is essential:
+
+| Stored Relationships | Computed Relationships |
+|---------------------|------------------------|
+| Explicitly created by you | Derived from rules |
+| You write them (via resource reports, role bindings) | You query them (via Check, StreamedListObjects) |
+| Managed through write operations | Read-only evaluation |
+| Direct facts you store | Results of rules applied to stored relationships |
+
+**From an integrator perspective:**
+- You **create stored relationships** when you report resources, create role bindings, or manage access
+- You **query computed relationships** when you check permissions or list accessible resources
+
+## Querying Relationships
+
+Kessel provides several operations to query the authorization graph:
+
+### Check
+
+Answers: "Does this specific relationship exist?"
+
+**Example:** "Can Alice view a document?"
+```
+Check(
+  resource: "doc:readme",
+  relation: "viewer",
+  subject: "user:alice"
+) → ALLOWED_TRUE or ALLOWED_FALSE
+```
+
+This is the core permission check operation. It evaluates the relationship rules, follows graph connections, and returns whether the relationship is allowed.
+
+### StreamedListObjects
+
+Answers: "What resources does this subject have a relationship to?"
+
+**Example:** "What documents can Alice view?"
+```
+StreamedListObjects(
+  resource_type: "doc",
+  relation: "viewer",
+  subject: "user:alice"
+) → stream of document IDs
+```
+
+Useful for: Filtering lists based on permissions, showing users what they can access.
+
+### ListSubjects
+
+Answers: "What subjects have a relationship to this resource?"
+
+**Example:** "Who can view this document?"
+```
+ListSubjects(
+  resource: "doc:readme",
+  relation: "viewer"
+) → stream of subject IDs
+```
+
+Useful for: Auditing access, showing resource viewers/owners.
+
+## Connection to RBAC and Tenancy
+
+The relationships model is the foundation that makes RBAC and workspace hierarchy work:
+
+**Role bindings create relationships:**
+When you create a role binding granting the "Inventory Viewer" role to the Engineering group on the Production workspace, Kessel stores relationships connecting:
+- The binding to the role
+- The binding to the group  
+- The binding to the workspace
+
+**Workspace hierarchy uses indirect relations:**
+When you check if Alice can view a resource in a child workspace, Kessel:
+1. Finds the resource's workspace assignment (stored relationship)
+2. Follows parent workspace relationships (indirect relations)
+3. Checks if Alice has a role binding on any workspace in that chain
+
+**Groups use subject sets:**
+Instead of creating individual role bindings for each user, you create one binding to a group (subject set). As users join and leave the group, their effective permissions update automatically.
+
+See the [RBAC](../rbac) and [Tenancy](../tenancy) docs for how these concepts are applied in practice.
+
+## General Purpose, Not Just Access Control
+
+While this document focuses on authorization use cases, the relationships model is intentionally general-purpose. It can represent any graph of connections between resources:
+
+- Membership relationships (users in groups)
+- Ownership relationships (who owns what)
+- Hierarchical relationships (workspace trees, folder structures)
+- Notification subscriptions (who watches what)
+
+This generality is why Kessel uses "relation" and "relationship" terminology at this layer rather than permission-specific terms. The RBAC layer (roles, permissions, role bindings) is built on top of this general relationship model.
+
+## Next Steps
+
+<LinkCard
+  title="Role-based access control"
+  description="See how roles, permissions, and role bindings use the relationship model."
+  href="/docs/building-with-kessel/concepts/rbac/"
+/>
+
+<LinkCard
+  title="Identity and multi-tenancy"
+  description="Understand how workspace hierarchy uses indirect relations for permission inheritance."
+  href="/docs/building-with-kessel/concepts/tenancy/"
+/>
+
+<LinkCard
+  title="Resources and representations"
+  description="Learn how resources are reported and how that creates relationships in the authorization graph."
+  href="/docs/building-with-kessel/concepts/resources-representations/"
+/>

--- a/src/content/docs/building-with-kessel/concepts/resources-representations.mdx
+++ b/src/content/docs/building-with-kessel/concepts/resources-representations.mdx
@@ -1,38 +1,234 @@
 ---
 title: Resources and representations
+description: Understand Kessel's unified resource model, how resources are identified, and how multiple services share representations of the same resource through correlation.
 sidebar:
   order: 10
 ---
 
-Kessel is a platform for building integrated, multi-tenant services which share consistent resource organization and access semantics. It facilitates consistency through a common access model, resource correlation, resource relationships, service discovery, and events. In these explanations we'll break down what that means and how that is achieved.
+import { Aside, LinkCard } from '@astrojs/starlight/components';
 
-At its most basic level, Kessel is essentially a specialized database of resources and relationships between them. A <i>Resource</i> is any entity with a distinct identity that you can model with [JSON schema](https://json-schema.org/).
+Kessel is a platform for building integrated, multi-tenant services that share consistent resource organization and access semantics. At its core, Kessel treats **everything as a resource** — users, groups, workspaces, hosts, clusters, applications, and even roles are all modeled uniformly as resources with types, identifiers, and relationships.
 
-Like a database, all Kessel knows about without schema is a <i>meta-model</i> of resource types. These are defined via schema. Schema specifies a resource type's valid representations, reporters, correlation keys, and relationships. We'll explain each of these in turn.
+This unified resource model enables services to share state about the same real-world entities without tight coupling. Multiple services can report their own perspective on a resource, and Kessel correlates these perspectives into a coherent view. This document explains the core concepts: resources, representations, resource types, correlation, and why you would share resource data with Kessel.
 
-## A resource, in multiple perspectives
+## Core Concepts
 
-Consider a machine. Machines are managed or observed by many different services. Some services control the content available to the operating system. Some services observe or enforce security policies. Some services report metrics. Each of these services have their own state and their own identifiers for the machine. They may create their own objects in order to model different aspects of it.
+### Everything is a Resource
 
-A <i>representation</i> is the state of a resource according to a particular services. A service that reports resource representations to Kessel is called a <i>reporter</i>.
+In Kessel, a **resource** is any entity with a distinct identity that can be modeled, queried, and governed. Resources are the fundamental building blocks of both the inventory and the authorization system.
 
-In the machine example, an observability tool could be one reporter, and a content management tool could be another reporter.
+**Examples:**
+- `user:alice@redhat.com` — A user identity
+- `group:engineering` — A group of users
+- `workspace:prod-eng` — A workspace for organizing resources
+- `doc:project-proposal` — A document
+- `k8s_cluster:openshift-prod` — A Kubernetes cluster
+- `role:inventory-viewer` — A role granting permissions
 
-When there are multiple representations of the same resource, we need some way to tell that two resource representations are _actually_ two representations about the _same_ resource. This is done with <i>correlation</i>–attributes which are used as keys to identify a resource. Sometimes, this is trivial. When a cloud provider provides a metadata document for a machine, the platform gives everyone a consistent and single identifier for a resource. We are not always so fortunate.
+The key insight is that Kessel does not distinguish between "data resources" (like documents) and "identity resources" (like users) at the model level. They are all resources with types, identifiers, attributes, and relationships to other resources.
 
-Each representation has its own attribute schema, defined in JSON schema.
+### Resource Types
 
-Reporting representation updates is a kind of [event](../events). The other kind of event is a deletion. A delete event occurs when a reporter reports the resource deleted, either because they have deleted it themselves, or no longer wish it to be integrated.
+A **resource type** defines the category of a resource. Resource types are configured via schema and specify:
 
-Schemas are also used to tell which JSON property refers to a [relationship](../relationships-permissions) with another resource.
+- Valid **representations** (different services' perspectives on the resource)
+- Valid **reporters** (which services can report this resource type)
+- **Correlation keys** (attributes used to link representations) — *future capability*
+- **Relationships** (connections to other resource types)
 
-## Why share representations with Kessel?
+**Example resource types:**
+- `doc` — Document
+- `k8s_cluster` — Kubernetes cluster
+- `k8s_policy` — Kubernetes policy
+- `user` — User identity
+- `group` — Group of principals
+- `workspace` — Workspace for multi-tenancy
+- `role` — Role with permissions
 
-There are exactly and only three reasons to share attributes or relationships with Kessel:
+Resource types are part of Kessel's **meta-model** approach — the system does not hard-code specific resource types in its implementation. Instead, types are defined declaratively via schema, and Kessel's APIs operate generically over any configured resource type.
 
-1. **You need them for access control**. The typical example of this is a [Workspace](../tenancy) relationship. But, attributes may also be used for access control (e.g. a role can grant access only to Kubernetes clusters of a certain status)  
-2. **You need them for correlation**. When there are multiple reporters about the same resource, there must be some way to correlate that these are the same resource (e.g. external cluster ID associated with an OpenShift cluster).  
-3. **Other services or users need them in events or queries for integration**. If a service needs to react to a change, including that state in inventory tracks and publishes its changes so other services can react to it e.g. by listening to a Kafka topic.
+<Aside>
+  This schema-driven approach means new resource types can be added without changing Kessel's core code. See the [Schema](../schema) documentation for how resource types are defined.
+</Aside>
 
+### Resource References
 
+Resources are identified using a **resource reference** structure that specifies:
 
+- `type` — The resource type (e.g., `"doc"`, `"k8s_cluster"`, `"user"`)
+- `id` — The unique identifier within that type (e.g., `"project-proposal"`, `"alice@redhat.com"`)
+
+**Example resource reference:**
+```json
+{
+  "type": "doc",
+  "id": "a4e3bc87-3ae1-470b-a881-0cde23338662"
+}
+```
+
+The combination of type and ID uniquely identifies a resource within Kessel. This structure is used throughout the APIs:
+- When reporting resources to the inventory (`ReportResource`)
+- When creating relationships in the authorization graph (`CreateRelationship`)
+- When checking permissions (`Check`)
+- When querying resources (`ListResources`, `StreamedListObjects`)
+
+**Format conventions:**
+- UUIDs are preferred for service-generated IDs
+- Human-readable strings are acceptable for user-facing resources (e.g., usernames, group names)
+- IDs must be unique within a resource type but can be reused across different types
+
+## Representations
+
+A **representation** is the state of a resource. Kessel supports both common representations (shared across all reporters) and reporter-specific representations (unique to each service's perspective).
+
+### Common vs Reporter-Specific Representations
+
+Kessel supports two types of representations:
+
+**Common representations** — State shared across all reporters:
+
+Some attributes are not specific to any one reporter and represent facts about the resource itself. These go into a common representation that all reporters can contribute to.
+
+**Reporter-specific representations** — State maintained by a specific service:
+
+Each reporter has its own schema for the resource type. For example:
+- A content management service might track author, version, and modification history
+- A security service might track classification, encryption status, and compliance
+- An analytics service might track view counts, unique viewers, and read time
+
+All three services are reporting about the **same document**, but each has different attributes and concerns.
+
+**Example: Document resource with multiple representations**
+
+```mermaid
+graph LR
+    Doc["Document Resource<br/>project-proposal.pdf"]
+    
+    Doc --> Common["Common<br/>Representation"]
+    Doc --> Content["Content Management<br/>Representation"]
+    Doc --> Security["Security<br/>Representation"]
+    
+    Common --> C1["title<br/>workspace_id"]
+    Content --> CM1["author<br/>version<br/>last_modified"]
+    Security --> S1["classification<br/>encrypted"]
+```
+
+Each representation has its own schema defining valid attributes. When a service calls `ReportResource`, it specifies which representation it is updating.
+
+## Why Share Data with Kessel?
+
+There are two primary reasons to share resource attributes or relationships with Kessel:
+
+### 1. You Need Them for Access Control
+
+If access to a resource depends on an attribute or relationship, that data must be in Kessel. The authorization system evaluates permissions based on the authorization graph, which is built from resource reports.
+
+**Examples:**
+- A resource's **workspace assignment** determines which users can access it
+- A resource's **owner** relationship grants management permissions
+- A resource's **status** might restrict access (e.g., only production resources require elevated permissions)
+
+**What to report:**
+- Workspace relationships (required for multi-tenancy)
+- Owner or group assignments
+- Attributes used in permission rules (e.g., resource tags, compliance status)
+
+### 2. Other Services or Users Need Them for Integration
+
+If downstream services or external consumers rely on the data for automation, reporting, or decision-making, Kessel acts as the single source of truth.
+
+**Examples:**
+- Automation listening to Kafka events needs to know when a document's classification changes
+- Dashboards query Kessel for current resource inventory counts
+- Compliance audits pull historical state from the inventory database
+
+**What to report:**
+- Attributes that appear in dashboards or reports
+- State changes that trigger workflows or alerts
+- Data required for compliance or audit trails
+
+<Aside>
+  Do **not** report data just because you have it. Sending unnecessary attributes increases storage costs, replication load, and processing time. Report only what serves one of the two purposes above.
+</Aside>
+
+## Connection to the Schema
+
+The resource types and representations described in this document are defined using **schema**. Kessel's meta-model approach means you configure resource behavior through schema rather than writing custom code.
+
+This schema-driven design enables:
+- **Extensibility** — Add new resource types without changing Kessel's implementation
+- **Validation** — Enforce attribute types and constraints at write time
+- **Documentation** — Schema serves as machine-readable API contracts
+- **Flexibility** — Different reporters can have different schemas for the same resource type
+
+See the [Schema](../schema) documentation for details on how resource types are defined and configured.
+
+## Future Capabilities
+
+The following features are planned for future releases but not yet implemented in v1beta2.
+
+### Correlation (Planned)
+
+<Aside type="note">
+  **This feature is not yet implemented.** The correlation mechanism described below is planned but not available in the current v1beta2 release. Currently, each reporter's representation creates a separate resource in Kessel.
+</Aside>
+
+When multiple services report representations of the same resource, Kessel will need a way to determine that two representations refer to the **same logical resource**. This process is called **correlation**.
+
+**Correlation** will be the mechanism that links multiple representations into a single resource identity. Without correlation, each service's representation is treated as a separate, unrelated resource.
+
+**Example of planned correlation behavior:**
+- Content Management service reports document with `correlation_key = "doc-uuid-123"`
+- Security service reports document with `correlation_key = "doc-uuid-123"`
+- Analytics service reports document with `correlation_key = "doc-uuid-123"`
+- Kessel will correlate these representations because they share the same **correlation key**
+- Users will see **one document** with content, security, and analytics data
+
+**Planned correlation keys:**
+
+**External identifiers** — Most reliable when available:
+- Document UUID from storage system
+- File hash (SHA-256)
+- Persistent URL or URI
+
+**Storage provider metadata**:
+- Box file ID
+- SharePoint document ID
+- Google Drive file ID
+
+**Content identifiers**:
+- Digital Object Identifier (DOI)
+- ISBN for publications
+- Internal document number
+
+**Attribute combinations**:
+- Filename + workspace + creation timestamp
+- Author + title + version
+
+When this feature is implemented, correlation keys will be configured in the resource type schema, and Kessel will automatically match representations with the same correlation key values.
+
+## Next Steps
+
+<LinkCard
+  title="Relationships and permissions"
+  description="Learn how resources connect through relationships and how permissions are evaluated."
+  href="/docs/building-with-kessel/concepts/relationships-permissions/"
+/>
+
+<LinkCard
+  title="Identity and multi-tenancy"
+  description="Understand workspaces, principals, and how tenant isolation works."
+  href="/docs/building-with-kessel/concepts/tenancy/"
+/>
+
+<LinkCard
+  title="Schema-driven resource model"
+  description="See how resource types and representations are configured via schema."
+  href="/docs/building-with-kessel/concepts/schema/"
+/>
+
+<LinkCard
+  title="Report resources to inventory"
+  description="Step-by-step guide to reporting resource representations."
+  href="/docs/building-with-kessel/how-to/report-resources/"
+/>

--- a/src/content/docs/building-with-kessel/concepts/schema.mdx
+++ b/src/content/docs/building-with-kessel/concepts/schema.mdx
@@ -1,5 +1,216 @@
 ---
 title: Schema and extensibility
+description: Understand how Kessel uses JSON Schema to define resource types, representations, and relationships without hard-coding resource models.
 sidebar:
   order: 50
 ---
+
+import { Aside, LinkCard } from '@astrojs/starlight/components';
+
+<Aside type="caution">
+  **Schema implementation is evolving.** Kessel is moving toward a unified schema model that will cover relations, inventory data, and RBAC permissions. This document describes current concepts; specific file structures, configuration details, and the extent of schema-driven behavior may change.
+</Aside>
+
+Kessel is designed to be **extensible**. The system does not hard-code specific resource types like "host" or "cluster" into its implementation. Instead, resource types are defined declaratively using [JSON Schema](https://json-schema.org/), and Kessel's APIs operate generically over any configured resource type. This schema-driven approach enables services to define new resource types, customize representations, and evolve their data models without modifying Kessel's core code.
+
+This document explains the meta-model, how schemas define resource types, and how schema drives validation and relationships.
+
+## The Meta-Model
+
+Kessel's architecture is built on a **meta-model** — a model of models. Instead of knowing about specific resource types (hosts, clusters, users), Kessel knows about the structure that all resource types share:
+
+- **Type name** — A string identifying the resource category
+- **Representations** — Different services' perspectives on the resource
+- **Reporters** — Which services can report this resource type
+- **Correlation keys** — Attributes used to link representations
+- **Relationships** — Connections to other resource types
+
+When you report a resource, Kessel does not have built-in logic for "this is a host, so validate these specific fields." Instead, Kessel looks up the resource type's schema and validates the data against the schema's rules. This generic approach means **adding a new resource type is a configuration change, not a code change**.
+
+**Example:**
+
+To add a new resource type called `database_instance`:
+1. Write a JSON Schema defining the resource structure
+2. Register the schema with Kessel
+3. Start reporting resources of type `database_instance`
+
+No changes to Kessel's code or deployment are required.
+
+## JSON Schema Basics
+
+Kessel uses [JSON Schema (Draft 07)](http://json-schema.org/draft-07/schema) to define resource types and representations. JSON Schema is a standard vocabulary for describing JSON data structures, including:
+
+- **Types** — String, number, boolean, object, array
+- **Validation rules** — Required fields, formats, ranges, patterns
+- **Nested structures** — Objects within objects, arrays of objects
+- **Metadata** — Descriptions, titles, examples
+
+**Simple JSON Schema example:**
+```json
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "properties": {
+    "hostname": {
+      "type": "string",
+      "description": "Fully qualified domain name",
+      "pattern": "^[a-z0-9.-]+$"
+    },
+    "cpu_count": {
+      "type": "integer",
+      "minimum": 1,
+      "description": "Number of CPU cores"
+    },
+    "memory_gb": {
+      "type": "number",
+      "minimum": 0,
+      "description": "Total system memory in gigabytes"
+    }
+  },
+  "required": ["hostname"]
+}
+```
+
+This schema defines an object with three properties: `hostname` (required string), `cpu_count` (optional integer ≥1), and `memory_gb` (optional number ≥0).
+
+When a service calls `ReportResource` with a representation, Kessel validates the provided JSON against the appropriate schema. If the data does not match the schema (missing required field, wrong type, invalid format), the request is rejected with a validation error.
+
+## Resource Type Configuration
+
+A resource type configuration in Kessel specifies:
+
+### Type Name
+
+The unique identifier for the resource type. Convention is lowercase with underscores:
+- `host`
+- `k8s_cluster`
+- `k8s_policy`
+- `workspace`
+- `user`
+
+Type names must be unique within Kessel and are used in `ResourceReference` messages throughout the API.
+
+### Valid Reporters
+
+Each resource type can specify which reporters (services) are authorized to report that resource type. This ensures that only trusted services can create or update specific resource types.
+
+### Representation Schemas
+
+Resource types define schemas for:
+- **Common representation** — Shared attributes across all reporters
+- **Reporter-specific representations** — Each reporter's unique perspective on the resource
+
+These schemas are stored as JSON Schema files and loaded by Kessel at startup.
+
+## How Schema Drives Behavior
+
+### Validation
+
+When a service calls `ReportResource`, Kessel:
+1. Identifies the resource type from the request
+2. Looks up the schema for the specified representation type and reporter
+3. Validates the provided JSON data against the schema
+4. Rejects the request if validation fails
+
+**Example validation error:**
+```json
+{
+  "error": "Validation failed",
+  "details": [
+    {
+      "field": "cpu_count",
+      "message": "must be an integer, got string"
+    },
+    {
+      "field": "hostname",
+      "message": "required field missing"
+    }
+  ]
+}
+```
+
+This **fail-fast** approach prevents malformed data from entering the system and ensures data quality.
+
+### Automatic Workspace Relationship Creation
+
+<Aside type="note">
+  **Current implementation:** The `workspace_id` field is currently **hardcoded** in Kessel's logic. The future intention is to make relationship creation fully **schema-driven**, where the schema itself defines which fields trigger relationship creation and what type of relationships they create.
+</Aside>
+
+When a resource is reported with a `workspace_id` field in its common representation, Kessel automatically creates a workspace relationship tuple in the authorization graph.
+
+**Example workspace field in common representation schema:**
+```json
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "properties": {
+    "workspace_id": {
+      "type": "string"
+    }
+  },
+  "required": ["workspace_id"]
+}
+```
+
+When Kessel processes a resource report with `workspace_id: "abc-123"`:
+1. It validates the field against the JSON Schema
+2. It extracts the `workspace_id` value from the common representation
+3. It automatically creates a workspace relationship in the authorization graph:
+   ```
+   host:server-456#workspace@workspace:abc-123
+   ```
+
+Currently, the field is identified by **hardcoded naming convention** (`workspace_id`). The workspace relationship is created automatically as part of the resource report. In the future, the mechanism will become more flexible and schema-driven.
+
+## Extensibility in Practice
+
+### Adding a New Resource Type
+
+To define a new resource type, you provide:
+
+1. **Resource type definition** — Type name and authorized reporters
+2. **JSON Schemas** — Validation rules for common and reporter-specific representations
+3. **Register with Kessel** — Configuration is loaded at startup
+
+Once configured, you can immediately start reporting resources of that type using `ReportResource`. No changes to Kessel's source code are required — the system operates generically over any configured resource type.
+
+### Multi-Reporter Resources
+
+The schema-driven model is designed to support multiple reporters for the same resource type. Each reporter:
+- Provides its own representation schema
+- Reports independently without coordinating with other reporters
+
+<Aside type="note">
+  **Correlation is not yet implemented.** Currently, each reporter's representation creates a separate resource in Kessel. The future intention is to link multiple representations into a single resource identity through correlation keys.
+</Aside>
+
+**Example: `k8s_cluster` resource type**
+
+Different services can define schemas for the same resource type:
+- **Common representation**: Cluster name, cloud provider, region
+- **OpenShift Console reporter**: Console URL, installed operators
+- **Cost Management reporter**: Monthly cost, resource quotas
+- **Security reporter**: Compliance status, vulnerabilities
+
+When correlation is implemented, these representations will be linked and appear as a single `k8s_cluster` resource in queries.
+
+## Next Steps
+
+<LinkCard
+  title="Resources and representations"
+  description="Understand how resources, representations, and correlation work in Kessel."
+  href="/docs/building-with-kessel/concepts/resources-representations/"
+/>
+
+<LinkCard
+  title="Relationships and permissions"
+  description="Learn how schemas interact with the authorization graph and relationship rules."
+  href="/docs/building-with-kessel/concepts/relationships-permissions/"
+/>
+
+<LinkCard
+  title="Report resources to inventory"
+  description="Step-by-step guide to reporting resources with schema validation."
+  href="/docs/building-with-kessel/how-to/report-resources/"
+/>


### PR DESCRIPTION
This commit adds and refines concept documentation explaining Kessel's
architecture and core patterns:

- **coming-from-rbac-v1.mdx**: Explains conceptual differences between
  legacy RBAC v1 and Kessel-based RBAC v2, including permission format
  transformation, server-side wildcard handling, workspace hierarchy,
  graph-based authorization, and role bindings.

- **resources-representations.mdx**: Documents Kessel's unified resource
  model where everything (users, groups, workspaces, hosts, roles) is
  treated uniformly as a resource. Explains common vs reporter-specific
  representations and notes that correlation is planned for future.

- **relationships-permissions.mdx**: Explains the authorization graph
  model, including stored vs computed relationships, relationship rules
  (direct, inheritance, combination), and how to query relationships.

- **schema.mdx**: Documents the schema-driven extensibility approach
  using JSON Schema for validation and the meta-model design. Notes
  that schema implementation is evolving toward a unified model covering
  relations, inventory, and RBAC.

All documentation verified against current v1beta2 implementation and
marks features in development as future capabilities.
