### PR TITLE
RHCLOUD-47166: updates report-resource to true up and make more concise

### DIFF
--- a/src/content/docs/building-with-kessel/how-to/report-resources.mdx
+++ b/src/content/docs/building-with-kessel/how-to/report-resources.mdx
@@ -59,12 +59,15 @@ flowchart TD
 | **Write visibility** | Eventual (default) | Immediate | Eventual | Eventual |
 | **Atomicity guarantee** | Caller's responsibility | Caller's responsibility | Caller's responsibility | Built-in (single DB transaction) |
 | **Dual-write risk** | Yes, if not handled | Yes, if not handled | Yes, if not handled | None |
+| **Ordering and delivery** | Your app must handle both | Your app must handle both | Handled by Kafka | Handled by Kafka |
+| **Idempotency** | Your app must handle | Your app must handle | `transaction_id` covers Kessel API calls; additional consumer logic is your responsibility | `transaction_id` covers Kessel API calls; additional consumer logic is your responsibility |
+| **Retry handling** | Your app must implement retries and persist failed requests | Your app must implement retries and persist failed requests | Consumer loop handles retries; Kafka retains uncommitted messages | Consumer loop handles retries; Kafka retains uncommitted messages |
 | **Infrastructure** | None beyond Kessel | None beyond Kessel | Kafka | Kafka + Debezium |
-| **Consistency modes** | All modes supported | All modes, plus guaranteed write visibility | `minimize_latency`, `at_least_as_fresh` | `minimize_latency`, `at_least_as_fresh` |
+| **Consistency modes** | All modes supported | All modes, plus guaranteed write visibility | All modes supported | All modes supported |
 | **Best for** | Simple, low-volume integrations | Flows requiring read-after-write | Apps with existing Kafka infrastructure | High-volume or failure-sensitive apps |
 
 <Aside type="tip">
-  If you are unsure, start with the **API/SDK**. It is the simplest path, supports all [consistency modes](/building-with-kessel/concepts/consistency/#consistency-modes), and can use IMMEDIATE mode if you later need stronger write visibility. Move to async messaging only when your application has specific requirements around decoupling, fault tolerance, or throughput that direct API calls cannot meet.
+  If you are unsure, start with the **API/SDK**. It is the simplest path, supports all [consistency modes](/building-with-kessel/concepts/consistency/#consistency-modes), and can use IMMEDIATE mode if you later need stronger write visibility. Move to async messaging only when your application has specific requirements around decoupling, fault tolerance, or throughput that direct API calls cannot meet. If you choose an async approach, see [Kafka Consumer Strategies](#kafka-consumer-strategies) for implementation guidance on ordering, delivery, retries, and rebalance handling.
 </Aside>
 
 ## Reporting via API/SDK

--- a/src/content/docs/building-with-kessel/how-to/report-resources.mdx
+++ b/src/content/docs/building-with-kessel/how-to/report-resources.mdx
@@ -28,6 +28,45 @@ There are two main approaches, each with different trade-offs:
 - Only provides eventual consistency
 - May require additional infrastructure
 
+### Choosing an approach
+
+Your reporting strategy determines what [consistency guarantees](/building-with-kessel/concepts/consistency/) are available to your application. Direct API calls support all consistency modes, including read-after-write visibility. Async approaches provide eventual consistency, meaning there is no guaranteed upper bound on how long replication to the authorization backend takes, but generally its fractions of a second. Use this flowchart to determine which strategy fits your application.
+
+```mermaid
+flowchart TD
+    START(["How should I report<br/>resources to Kessel?"])
+    Q1{"Do you need permission checks<br/>to reflect writes immediately?"}
+    Q2{"Can your app guarantee<br/>atomicity, delivery, and ordering<br/>between DB writes and API calls?"}
+    Q3{"Can your app atomically<br/>publish events and write<br/>to its database?"}
+
+    API_IMM["✅ <strong>API/SDK + IMMEDIATE mode</strong><br/>Write visibility before response"]
+    API["✅ <strong>API/SDK</strong><br/>Simplest integration path"]
+    DIRECT["✅ <strong>Direct Publishing</strong><br/>Publish to Kessel-owned Kafka topic"]
+    OUTBOX["✅ <strong>Outbox Pattern + CDC</strong><br/>Transactional outbox with Debezium"]
+
+    START --> Q1
+    Q1 -- "Yes" --> API_IMM
+    Q1 -- "No, eventual consistency is fine" --> Q2
+    Q2 -- "Yes" --> API
+    Q2 -- "No" --> Q3
+    Q3 -- "Yes" --> DIRECT
+    Q3 -- "No" --> OUTBOX
+```
+
+| | API/SDK | API/SDK + IMMEDIATE | Direct Publishing | Outbox + CDC |
+|---|---|---|---|---|
+| **Complexity** | Low | Low | Medium | Higher |
+| **Write visibility** | Eventual (default) | Immediate | Eventual | Eventual |
+| **Atomicity guarantee** | Caller's responsibility | Caller's responsibility | Caller's responsibility | Built-in (single DB transaction) |
+| **Dual-write risk** | Yes, if not handled | Yes, if not handled | Yes, if not handled | None |
+| **Infrastructure** | None beyond Kessel | None beyond Kessel | Kafka | Kafka + Debezium |
+| **Consistency modes** | All modes supported | All modes, plus guaranteed write visibility | `minimize_latency`, `at_least_as_fresh` | `minimize_latency`, `at_least_as_fresh` |
+| **Best for** | Simple, low-volume integrations | Flows requiring read-after-write | Apps with existing Kafka infrastructure | High-volume or failure-sensitive apps |
+
+<Aside type="tip">
+  If you are unsure, start with the **API/SDK**. It is the simplest path, supports all [consistency modes](/building-with-kessel/concepts/consistency/#consistency-modes), and can use IMMEDIATE mode if you later need stronger write visibility. Move to async messaging only when your application has specific requirements around decoupling, fault tolerance, or throughput that direct API calls cannot meet.
+</Aside>
+
 ## Reporting via API/SDK
 
 Service providers can report resources directly to Kessel using gRPC API calls or one of the available SDKs for [Go](https://github.com/project-kessel/kessel-sdk-go), [Python](https://github.com/project-kessel/kessel-sdk-py), [Node.js](https://github.com/project-kessel/kessel-sdk-node), [Ruby](https://github.com/project-kessel/kessel-sdk-ruby), or [Java](https://github.com/project-kessel/kessel-sdk-java). The API schema is available in the [Buf Schema Registry](https://buf.build/project-kessel), with the primary endpoint being [`ReportResourceRequest`](https://buf.build/project-kessel/inventory-api/docs/main:kessel.inventory.v1beta2#kessel.inventory.v1beta2.ReportResourceRequest).

--- a/src/content/docs/building-with-kessel/how-to/report-resources.mdx
+++ b/src/content/docs/building-with-kessel/how-to/report-resources.mdx
@@ -1,5 +1,6 @@
 ---
 title: Report resources
+description: "Strategies for reporting resources to Kessel, including direct API calls, CDC, and the outbox pattern."
 sidebar:
   order: 40
 ---
@@ -7,57 +8,55 @@ sidebar:
 import { Aside } from "@astrojs/starlight/components";
 import { LinkCard } from "@astrojs/starlight/components";
 
-<Aside title="Under Construction">
-  We are working on improving this documentation, some sections may be missing or incomplete
-</Aside>
-
 This guide provides service providers with strategies for reliably replicating data into the Management Fabric. Successful integration requires navigating the complexities of distributed systems by selecting appropriate strategies that solve for consistency, resiliency, and durability. Depending on what guarantees your system needs, you can expect to face some challenges such as the [dual-write problem](https://www.confluent.io/blog/dual-write-problem/), [write skew](https://www.cockroachlabs.com/blog/what-write-skew-looks-like/), and more. This guide will help you understand how to address these challenges and implement a replication strategy that aligns with your application's requirements.
 
 # Reporting Resources
 
-Reporting resources to the Management Fabric is essential for leveraging its authorization and access control capabilities. A resource represents any business entity that requires access control - orders, customers, products, virtual machines, subscriptions, or any other domain-specific entity. This guide covers approaches for reporting resources, each with distinct trade-offs in terms of consistency, complexity, and infrastructure requirements.
+A resource is any entity in your application that needs access control: orders, customers, virtual machines, subscriptions, or anything else.
+
+There are two main approaches, each with different trade-offs:
 
 1. **Reporting via API/SDK**
 
-- This is the simplest way to report resources to Kessel
-- Supports immediate visibility of data changes in Kessel
-- Your application must be able to guarantee atomicity, delivery, and order of events when reporting to Kessel
+- The simplest way to report resources to Kessel
+- Supports immediate visibility of data changes
+- Your application must guarantee atomicity, delivery, and ordering of events
 
 2. **Reporting via Async Messaging (Kafka, Change Data Capture, etc.)**
 
-- This is an alternative way to report resources to Kessel for applications that cannot guarantee delivery or order via
-  plain old API calls from their application.
-- Async operations afford only eventual consistency
-- May require additional infrastructure to setup and maintain
+- Better for applications that cannot guarantee delivery or ordering through direct API calls
+- Only provides eventual consistency
+- May require additional infrastructure
 
 ## Reporting via API/SDK
 
-Service providers can report resources directly to Kessel using gRPC API calls or one of the available SDKs for [Go](https://github.com/project-kessel/kessel-sdk-go), [Python](https://github.com/project-kessel/kessel-sdk-py), [Node.js](https://github.com/project-kessel/kessel-sdk-node), or [Ruby](https://github.com/project-kessel/kessel-sdk-ruby). The API schema is available in the [Buf Schema Registry](https://buf.build/project-kessel), with the primary resource reporting endpoint being [`ReportResourceRequest`](https://buf.build/project-kessel/inventory-api/docs/main:kessel.inventory.v1beta2#kessel.inventory.v1beta2.ReportResourceRequest). Direct API calls provide immediate visibility of data changes and synchronous error handling, making them ideal for simple integration scenarios. However, your application is responsible for ensuring atomicity, guaranteed delivery, and proper ordering of events - the API itself provides no built-in guarantees for consistency or durability if your application fails between database writes and API calls.
+Service providers can report resources directly to Kessel using gRPC API calls or one of the available SDKs for [Go](https://github.com/project-kessel/kessel-sdk-go), [Python](https://github.com/project-kessel/kessel-sdk-py), [Node.js](https://github.com/project-kessel/kessel-sdk-node), [Ruby](https://github.com/project-kessel/kessel-sdk-ruby), or [Java](https://github.com/project-kessel/kessel-sdk-java). The API schema is available in the [Buf Schema Registry](https://buf.build/project-kessel), with the primary endpoint being [`ReportResourceRequest`](https://buf.build/project-kessel/inventory-api/docs/main:kessel.inventory.v1beta2#kessel.inventory.v1beta2.ReportResourceRequest).
+
+Direct API calls give you immediate visibility and synchronous error handling, which makes them a good fit for simple integrations. However, your application is responsible for atomicity, guaranteed delivery, and ordering. The API does not provide built-in consistency or durability guarantees if your application fails between database writes and API calls.
 
 ## Reporting via Async Messaging
 
-Asynchronous messaging provides a robust alternative to direct API calls when your application requires decoupled, fault-tolerant data replication. Unlike synchronous API calls that can fail due to network issues, service unavailability, or transient errors, async messaging patterns offer built-in resilience through message persistence, retry mechanisms, and eventual consistency guarantees. This approach is particularly valuable for high-volume applications or those that cannot afford to block business operations while waiting for external service acknowledgments.
+Asynchronous messaging is a good alternative when your application needs decoupled, fault-tolerant data replication. Unlike direct API calls that can fail due to network issues or service unavailability, async messaging offers built-in resilience through message persistence, retries, and eventual consistency. This approach works well for high-volume applications or those that cannot block business operations while waiting for external acknowledgments.
 
 ### Direct Publishing
 
-Your application can publish resource events directly to a Kessel-owned Kafka topic for resource ingestion. However you will need to be sure your event publishing and saving to your database are done atomically. It may be necessary to implement a pattern like an outbox to help afford this.
+Your application can publish resource events directly to a Kessel-owned Kafka topic for resource ingestion. You will need to make sure your event publishing and database writes happen atomically. You may need to implement a pattern like an outbox to achieve this.
 
 ### Change Data Capture (CDC)
 
-Change Data Capture is a technique that allows you to capture changes to specific database tables and publish them to a message broker. This is a more robust way to report resources to Kessel for applications that cannot guarantee delivery or order via plain old API calls. This of course comes at the cost of more infrastructure set up and latency. Our recommended CDC tool is [Debezium](https://debezium.io/) which can attach to your database and publishes changes to a Kafka topic.
+Change Data Capture is a technique that allows you to capture changes to specific database tables and publishes them to a message broker. This is more robust than direct API calls for applications that cannot guarantee delivery or ordering, but comes with additional infrastructure and latency. Our recommended CDC tool is [Debezium](https://debezium.io/), which attaches to your database and publishes changes to a Kafka topic.
 
 #### Why Use CDC?
 
-Writing to your database and publishing events to a message broker are two distinct operations on external systems that
-cannot happen in an atomic manner in many cases(aka Dual Write Problem). This means that if your application crashes after writing to the database but before publishing an asynchronous event, your database and any message consumers may become permanently out of sync. By using Change Data Capture (CDC) you can ensure that writes to your database are published to a message broker only when the transactions are successfully committed.
+Writing to your database and publishing events to a message broker are two separate operations that cannot happen atomically in many cases (the [dual-write problem](https://www.confluent.io/blog/dual-write-problem/)). If your application crashes after the database write but before publishing the event, your database and message consumers can get permanently out of sync. CDC solves this by publishing events only when database transactions are successfully committed.
 
 ## The Outbox Pattern
 
-The outbox pattern helps solve this problem by writing resource aggregates and messaging events within the same database transaction using an outbox table. When coupled with something like [Debezium](https://debezium.io/) for change data capture, the outbox table can be used to publish events to a message broker, ensuring that your database and downstream message consumers are eventually in sync.
+The outbox pattern writes both your business data and messaging events within the same database transaction, using a dedicated outbox table. When paired with [Debezium](https://debezium.io/) for CDC, the outbox table feeds events to a message broker, keeping your database and downstream consumers eventually in sync.
 
 ### The Outbox Table
 
-This example uses a similar structure as the [Debezium Outbox Event Router](https://debezium.io/documentation/reference/stable/transformations/outbox-event-router.html#basic-outbox-table) example.
+This example follows a similar structure to the [Debezium Outbox Event Router](https://debezium.io/documentation/reference/stable/transformations/outbox-event-router.html#basic-outbox-table) example.
 
 ```sql
 CREATE TABLE outbox (
@@ -73,87 +72,92 @@ CREATE TABLE outbox (
 
 **Column Breakdown:**
 
-- **id:** A unique identifier for each event, your primary key
-- **aggregatetype:** Describes the type of business entity that an event relates to, for example, customer or order.
-  This is used by Debezium to determine the destination topic.
-- **aggregateid:** The unique identifier of the specific entity instance, like the customer's ID or order number.
-- **version:** Indicates the Kessel API version of the event, i.e. `v1beta2`
-- **operation:** Indicates the Kessel API method that will be called to process the event, i.e. `ReportResource`
-- **payload:** The actual content of the event message. This should be the same as the request body of the `ReportResourceRequest` API call.
+- **id:** A unique identifier for each event (primary key)
+- **aggregatetype:** The type of business entity the event relates to (e.g. `customer`, `order`).
+  Debezium uses this to determine the destination topic.
+- **aggregateid:** The unique identifier of the specific entity instance (e.g. customer ID, order number).
+- **version:** The Kessel API version of the event (e.g. `v1beta2`)
+- **operation:** The Kessel API method to call when processing the event (e.g. `ReportResource`)
+- **payload:** The event content. This should match the request body of the `ReportResourceRequest` API call.
 
 ### Writing to the Outbox
 
 With the outbox table in place, you'll need to modify your application's business logic to write to it within the same
 transaction as your primary data changes.
 
-For example, if you're creating a new customer and want to publish an event about it, you could consider your
-transaction looking something like this:
+For example, creating a new customer and publishing an event about it:
 
 ```sql
 BEGIN;
 INSERT INTO customers (id, name) VALUES ('123', 'John Doe');
 INSERT INTO outbox (id, aggregatetype, aggregateid, version, operation, payload)
-VALUES ('456', 'customer', '123', 'v1beta2', 'ReportResource', '{"event": "customer_created", "data": {"id": "123", "name": "John Doe"}}');
+VALUES ('456', 'customer', '123', 'v1beta2', 'ReportResource', '{"type":"customer","reporter_type":"my-reporter","reporter_instance_id":"redhat","representations":{"metadata":{"..."},"common":{"..."},"reporter":{"..."}}}');
 COMMIT;
 ```
 
-This ensures that both the customer record and the outbox event are created atomically. If the transaction fails, neither the customer nor the outbox entry will be written, maintaining consistency between your business entity data and downstream consumers.
+This ensures both the customer record and the outbox event are created atomically. If the transaction fails, neither is written.
+
+### Transaction IDs and Idempotency
+
+The Inventory API supports a `transaction_id` field on `ReportResourceRequest` (via `RepresentationMetadata.transaction_id`) that enables idempotent processing. If a request arrives with a `transaction_id` that has already been processed, the API skips it silently.
+
+For outbox-based integrations, include the `transaction_id` in your outbox event's `payload` field, since the payload mirrors the API request body.
 
 ### Pruning the Outbox
 
-To prevent the outbox table from growing indefinitely, you will need to implement a cleanup strategy.
+To prevent the outbox table from growing indefinitely, you need a cleanup strategy.
 
-With Debezium, since it will be reading from the [write-ahead log](https://www.postgresql.org/docs/current/wal-intro.html), you can safely delete entries from the outbox table immediately; even within the same transaction that created them.
+With Debezium, since it reads from the [write-ahead log](https://www.postgresql.org/docs/current/wal-intro.html), you can safely delete entries from the outbox table immediately, even within the same transaction that created them.
 
 ```sql
 BEGIN;
 INSERT INTO customers (id, name) VALUES ('123', 'John Doe');
 INSERT INTO outbox (id, aggregatetype, aggregateid, version, operation, payload)
-  VALUES ('456', 'customer', '123', 'v1beta2', 'ReportResource', '{"event": "customer_created", "data": {"id": "123", "name": "John Doe"}}');
+  VALUES ('456', 'customer', '123', 'v1beta2', 'ReportResource', '{"type":"customer","reporter_type":"my-reporter","reporter_instance_id":"redhat","representations":{"metadata":{"..."},"common":{"..."},"reporter":{"..."}}}');
 DELETE FROM outbox WHERE id = '456';
 COMMIT;
 ```
 
-If you need to retain history for auditing, debugging, or recovery purposes, consider implementing a retention policy or
-reconciler that archives old events to a separate table, long-term data store, or even deletes them entirely. It's
-important to note that any retained events will not be ordered by transaction commit order inherently. You may need
-additional mechanisms in your application or database to ensure outbox ordering, such as using a serial primary key.
+If you need to retain history for auditing, debugging, or recovery, consider a retention policy or reconciler that archives old events to a separate table or long-term store. Note that retained events will not be ordered by transaction commit order inherently. You may need additional mechanisms like a serial primary key to ensure ordering.
+
+<Aside type="tip">
+Even if you delete outbox rows immediately, consider logging or archiving events before deletion. Retained outbox history can be critical for detecting inconsistencies between your database and Kessel, such as failed resource deletions that leave stale authorization data.
+</Aside>
 
 ### Monitoring
 
-**Outbox Event Creation**: Tracking the rate of event creation in combination with the rate of event consumption can help identify end-to-end lag in your system. If the outbox is filling up faster than it can be processed, you may need to scale your consumers or optimize your event processing logic.
+**Outbox Event Creation**: Track the rate of event creation alongside event consumption to identify lag in your system. If the outbox is filling up faster than events are processed, you may need to scale your consumers or optimize event processing.
 
-See our **Monitoring Data Replication** guide for more details on how to monitor your replication processes.
+See our **Monitoring Data Replication** guide for more details.
 
 <LinkCard
   title="Monitoring Data Replication in Inventory API"
-  href="/running-kessel/monitoring-kessel/monitoring-data-replication-inventory-api"
+  href="/running-kessel/monitoring-kessel/monitoring-data-replication-inventory-api/"
 />
 
 ### Beware: Write Skew
 
-Interleaved database writes could lead to [write skew issues](https://www.cockroachlabs.com/blog/what-write-skew-looks-like/), where concurrent application read-modify-write cycles could be operating on stale data causing silent corruption. It's advisable to take this into consideration when designing your outbox and event processing logic.
+Interleaved database writes can lead to [write skew issues](https://www.cockroachlabs.com/blog/what-write-skew-looks-like/), where concurrent read-modify-write cycles operate on stale data and cause silent corruption. Keep this in mind when designing your outbox and event processing logic.
 
 ## Immediate Write Visibility with Asynchronous Messaging
 
-For use cases where immediate visibility of data changes are required, but are bound by the nature of asynchronous event processing, you can consider using Postgres [LISTEN](https://www.postgresql.org/docs/current/sql-listen.html) and [NOTIFY](https://www.postgresql.org/docs/current/sql-notify.html) features. This can afford your request handler to wait for a notification related to the outcome of event consumption (e.g. replicating to kessel) before proceeding or returning to the client.
+If you need immediate visibility of data changes but are using asynchronous event processing, consider using Postgres [LISTEN](https://www.postgresql.org/docs/current/sql-listen.html) and [NOTIFY](https://www.postgresql.org/docs/current/sql-notify.html). This lets your request handler wait for a notification about the outcome of event consumption (e.g. replication to Kessel) before returning to the client.
 
 ### How it works
 
 The process is fairly straightforward:
 
-- **Produce & Listen:** The request handler produces an event to a Kafka topic (directly or via an outbox table) and then begins LISTENing on a Postgres channel.
-- **Consume & Notify:** A separate consumer process parses the event. Upon completion, it issues a NOTIFY command to the same channel the request handler is listening on.
-- **Synchronize:** The LISTENing request handler receives this notification, confirming that the event has been successfully consumed. This allows the handler to then continue its execution, for example, by returning a response to the client.
+- **Produce & Listen:** The request handler produces an event to a Kafka topic (directly or via an outbox table) and begins LISTENing on a Postgres channel.
+- **Consume & Notify:** A separate consumer processes the event. On completion, it issues a NOTIFY to the channel the request handler is listening on.
+- **Synchronize:** The request handler receives the notification, confirming the event was processed, and can return a response to the client.
 
-This approach effectively creates a synchronous workflow over an asynchronous workflow, ensuring that request handlers can await the completion of downstream event processing.
+This creates a synchronous workflow on top of the async pipeline, so request handlers can wait for downstream processing to complete.
 
 ### Examples
 
 #### Listening on a Postgres channel
 
-To listen for notifications on a specific Postgres channel, you can use the `LISTEN` command. The example below listens
-on the `host-replication` channel. Channels are arbitrarily defined strings that you can use to group related notifications.
+To listen for notifications on a specific Postgres channel, use the `LISTEN` command. Channels are arbitrary strings you define to group related notifications.
 
 ```sql
 LISTEN "host-replication";
@@ -161,8 +165,7 @@ LISTEN "host-replication";
 
 #### Notifying a Postgres channel
 
-The SQL below sends a notification to all listeners on the `host-replication` channel. The payload can be any string,
-but in this example, it is a UUID that could be used to identify the specific event or request.
+Send a notification to all listeners on a channel. The payload can be any string. In this example it is a UUID that identifies the specific event or request.
 
 ```sql
 NOTIFY "host-replication", 'c0740fcd-c2a3-4767-b2d2-fd21cd12e31a';
@@ -170,64 +173,39 @@ NOTIFY "host-replication", 'c0740fcd-c2a3-4767-b2d2-fd21cd12e31a';
 
 ### Considerations
 
-- LISTEN/NOTIFY may not be supported by all database drivers, you should double-check that your current postgres driver
-  can handle it.
-- Postgres channels are not durable, meaning that if the request handler is not actively listening when the NOTIFY is
-  sent, it will miss the notification. Listening should be one of the first things you do in your request handler.
-- You may run into limitations if your Postgres channels are ephemeral, so it is not advised to create and drop channels
-  frequently. Instead, use a consistent channel name for each type of event you want to listen for. This means that you
-  may have many listeners on the same channel and your event/notification payloads should have some identifier to
-  distinguish which event the listener is interested in.
-- LISTEN/NOTIFY should use it's own pg connection, separate from the one used for your application logic. This is
-  because LISTEN/NOTIFY is a long-lived operation that can block other operations on the same connection. You should also
-  aim to minimize connections in a way that each new LISTEN does not produce a new connection, but rather reuses an
-  existing one.
+- LISTEN/NOTIFY may not be supported by all database drivers. Check that your Postgres driver handles it.
+- Postgres channels are not durable. If the request handler is not actively listening when the NOTIFY fires, it misses the notification. Start listening before producing the event.
+- Avoid creating and dropping channels frequently. Use a consistent channel name for each event type. Multiple listeners can share the same channel; use identifiers in the notification payload to distinguish events.
+- LISTEN/NOTIFY should use its own database connection, separate from your application logic. It is a long-lived operation that can block other operations on the same connection. Reuse connections rather than creating a new one per LISTEN.
 
 ## Kafka Consumer Strategies
 
-As a service provider, you need a reliable way to replicate data changes from your systems to the Fabric.
-A Kafka consumer offers a robust and scalable pattern to solve this problem. A consumer reads messages from Kafka topics by subscribing to topic partitions.
-The consuming application then processes the messages to apply those changes.
-
-This guide outlines the key challenges your consumer should address and provides
-some high-level strategies for building a robust solution.
+If your async integration involves building your own consumer to process events and call the Kessel API, this section covers the key challenges and strategies for making it reliable.
 
 We built our consumer in Go using the [confluent-kafka-go](https://github.com/confluentinc/confluent-kafka-go) client library.
 
 ### Why Use a Kafka Consumer for Replication?
 
-When replicating data, a Kafka consumer solves the core problem of reliably processing asynchronous messages.
-It decouples your primary service from the replication process, meaning an issue in the replication pipeline won't
-directly impact your main application's performance.
+A Kafka consumer decouples your primary service from the replication process. This ensures issues in the replication pipeline won't directly impact your main application's performance.
 
 ### Key Guarantees for Data Integrity
 
-To maintain data consistency between your service and Kessel, your consumer implementation
-should prioritize data integrity. Below are three guarantees that we aim to enforce with our own consumer
-that you should too.
+To keep data consistent between your service and Kessel, your consumer should enforce these three guarantees:
 
 1. **Messages must be processed in order:**
-   If messages are not processed in the order in which they are received we risk applying changes in a manner
-   that causes unexpected consequences. For example, processing an `update` event before a `create` event for the
-   same record would fail and cause data issues.
+   For example, processing an `update` before a `create` for the same record will fail and cause data issues.
 
-2. **Guarantee At-least-once processing:**
-   A consumer must never "lose" a message. In other words, we should not be continuing
-   to process the next message until the current one has been confirmed to be processed.
-   Without this guarantee we risk losing data and will have permanent inconsistency for the “skipped” event.
+2. **Guarantee at-least-once processing:**
+   Never skip a message. Do not move to the next message until the current one is confirmed processed. Without this, you risk permanent inconsistency for skipped events.
 
 3. **Processing should be idempotent:**
-   If a message is processed more than once, it should not cause any side effects or data corruption.
-   This means that if a message is reprocessed due to a failure or retry, the outcome should be the same as if it were
-   processed only once. This comes with a caveat that if a "historical" message is replayed, all messages after it also
-   be reprocessed in order to ensure no data loss.
+   If a message is processed more than once, it should not cause side effects or data corruption. If a historical message is replayed, all subsequent messages must also be reprocessed in order.
 
 ### Authentication
 
-To read from a secured Kafka cluster, a consumer must first authenticate itself with the brokers.
-This is configured in the consumer's properties. For our setup we use SASL with the SCRAM-SHA-512 mechanism.
+To read from a secured Kafka cluster, your consumer must authenticate with the brokers. For our setup we use SASL with the SCRAM-SHA-512 mechanism.
 
-A typical configuration would look like this:
+A typical configuration:
 
 ```yaml
 security-protocol: sasl_plaintext
@@ -236,127 +214,128 @@ sasl-username: my-generic-consumer
 sasl-password: <PASSWORD>
 ```
 
-Your consumer configuration must include properties like `security.protocol`, `sasl.mechanism`,
-and other related settings to provide the necessary credentials for a successful connection to Kafka.
+Your consumer configuration must include properties like `security.protocol`, `sasl.mechanism`, and related settings for a successful connection.
 
 ### Retry Logic
 
-Message processing can fail for many reasons. Some failures are transient (e.g. a temporary network failure),
-while others are permanent (e.g. a malformed message). A robust consumer must handle these failures without halting all
-processing.
+Message processing can fail for transient reasons (network issues) or permanent ones (malformed messages). A robust consumer must handle failures without halting all processing.
 
-Our implementation uses two retry systems to handle message failures, prioritizing
-message durability over pure throughput.
+Our implementation uses two retry layers:
 
 1. **Operation-level Retry:**
-   For transient failures within a specific task, a blocking `Retry` function is used.
+   For transient failures within a specific task, a blocking retry function retries with exponential backoff.
 
 ```go
-// Retry executes the given function and will retry on failure with backoff until max retries is reached
-func (i *InventoryConsumer) Retry(operation func() (string, error)) (string, error) {
-    // ...
-    for i.RetryOptions.OperationMaxRetries == -1 || attempts < i.RetryOptions.OperationMaxRetries {
-        resp, err = operation()
-        if err != nil {
-            // ... logs error, increments metric
-            time.Sleep(backoff) // Blocks here
-            continue
+// retry executes the given operation with exponential backoff.
+// Set maxRetries to -1 for unlimited retries.
+func retry(operation func() error, maxRetries int, initialBackoff time.Duration) error {
+    backoff := initialBackoff
+    for attempt := 0; maxRetries == -1 || attempt < maxRetries; attempt++ {
+        err := operation()
+        if err == nil {
+            return nil
         }
-        return fmt.Sprintf("%s", resp), nil
+        log.Printf("attempt %d failed: %v, retrying in %s", attempt+1, err, backoff)
+        time.Sleep(backoff)
+        backoff *= 2
     }
-    // ...
+    return fmt.Errorf("operation failed after %d retries", maxRetries)
 }
 ```
 
-This function synchronously retries a failing operation with an exponential backoff up to a configured maximum.
-Because it uses `time.Sleep`, it blocks the consumer's main processing loop.
+This retries a failing operation synchronously with exponential backoff up to a configured maximum. Because it uses `time.Sleep`, it blocks the consumer's main processing loop.
 
 2. **Consumer-Level Retry:**
-   If a message fails processing in a way that the Consume loop cannot recover from (indicated by `consumer.ErrClosed`),
-   a more drastic retry strategy is engaged.
+   If the consume loop cannot recover (e.g. the consumer connection is closed), a more drastic retry recreates the entire consumer connection.
 
 ```go
-// Outer consumer loop
-for consumerOptions.RetryOptions.ConsumerMaxRetries == -1 || retries < consumerOptions.RetryOptions.ConsumerMaxRetries {
-    // ... recreates the entire consumer connection
-    inventoryConsumer, err = consumer.New(...)
-    err = inventoryConsumer.Consume()
-    if e.Is(err, consumer.ErrClosed) {
-        // ... backs off and retries by re-entering the loop
+// runConsumerWithRetry creates a Kafka consumer and begins polling.
+// If the consumer closes unexpectedly, it recreates the connection
+// and resumes from the last committed offset.
+// Set maxRetries to -1 for unlimited retries.
+for maxRetries == -1 || retries < maxRetries {
+    consumer, err := createConsumer(config)
+    if err != nil {
+        log.Printf("failed to create consumer: %v", err)
+        retries++
+        time.Sleep(backoff)
         continue
     }
-    // ...
+
+    err = consumer.Poll(ctx)
+    if errors.Is(err, ErrConsumerClosed) {
+        log.Printf("consumer closed unexpectedly, recreating (attempt %d)", retries+1)
+        retries++
+        time.Sleep(backoff)
+        backoff *= 2
+        continue
+    }
+    break
 }
 ```
 
-This strategy ensures a failed message is re-attempted from scratch by forcing a re-read from the last
-committed offset, preventing potential message loss.
+This forces a re-read from the last committed offset, preventing message loss.
 
 ### Rebalances
 
-Rebalances are critical to handle, as if your consumer loses a partition without first saving its progress
-the next consumer will start processing from the last saved point, leading to duplicate processing.
+Rebalances are critical to handle correctly. If your consumer loses a partition without saving its progress, the next consumer will start from the last saved point, leading to duplicate processing.
 
-Our consumer handles partition reassignments from the Kafka cluster by registering a `RebalanceCallback`. This
-ensures its processing state is committed before partitions are lost.
+Our consumer handles partition reassignments by registering a `RebalanceCallback` that commits progress before partitions are lost.
 
 ```go
-func (i *InventoryConsumer) RebalanceCallback(consumer *kafka.Consumer, event kafka.Event) error {
+// rebalanceCallback handles Kafka partition reassignments.
+// When partitions are revoked, it commits the current offsets
+// to prevent the next consumer from reprocessing completed messages.
+func rebalanceCallback(consumer *kafka.Consumer, event kafka.Event) error {
     switch ev := event.(type) {
-    // ...
     case kafka.RevokedPartitions:
-        i.Logger.Warnf("consumer rebalance event: %d partition(s) revoked: %v\n",
-            len(ev.Partitions), ev.Partitions)
+        log.Printf("partitions revoked: %v", ev.Partitions)
 
-        // Commits stored offsets before partition is lost
-        err := i.commitStoredOffsets()
-        // ...
+        _, err := consumer.Commit()
+        if err != nil {
+            log.Printf("failed to commit offsets during rebalance: %v", err)
+            return err
+        }
+    case kafka.AssignedPartitions:
+        log.Printf("partitions assigned: %v", ev.Partitions)
     }
     return nil
 }
 ```
 
-When the consumer is notified that it is about to lose ownership of its partitions, it calls `commitStoredOffsets()`. This
-is essential to guarantee that all successfully processed messages before this point have been marked as complete.
-This prevents the next consumer that receives the partition from reprocessing messages, maintaining the at-least-once
-processing guarantee.
+When the consumer is notified it is about to lose partitions, it commits offsets. This prevents the next consumer from reprocessing already-completed messages.
 
 ### Leveraging Client Statistics
 
-In addition to application level metrics (e.g. "events processed"), most Kafka client libraries
-can be configured to emit internal performance statistics, often as JSON. These "stats messages" provide a deep,
-real-time view into the health and performance of the consumer client itself.
+Most Kafka client libraries can emit internal performance statistics as JSON. These provide a real-time view of your consumer client's health.
 
-To enable this you typically set a configuration property like `statistics.interval.ms` to a non-zero value
-(e.g. 60000 for every 60 seconds). The client will then periodically provide a detailed report containing metrics such as:
+To enable this, set `statistics.interval.ms` to a non-zero value (e.g. 60000 for every 60 seconds). The client will periodically report metrics such as:
 
 - **Round-trip time (rtt)**
 - **Total messages consumed (rxmsgs)**
 
-These stats messages metrics are invaluable for debugging. You can use these metrics in dashboards and alerts we offer
-or build your own to track the health of the consumer.
+These metrics are useful for debugging and can feed into dashboards and alerts.
 
 ### Deployment
 
-How you deploy your consumer has a few key considerations, with 3 main ways to do so.
+How you deploy your consumer has a few key considerations:
 
 1. **In-process thread (used by the Kessel team)**
 
-- Consumer logic runs as a thread within the main application process.
-- Simple to deploy and manage without any network overhead for communication.
-- Tightly coupled resources. A CPU and memory intensive task in the main application can
-  starve the consumer thread and vice versa.
-- Cannot scale the consumer independently from the main application.
+- Runs as a thread within the main application process
+- Simple to deploy with no network overhead
+- Tightly coupled resources: a CPU-intensive task in the main application can starve the consumer and vice versa
+- Cannot scale the consumer independently
 
 2. **Sidecar container**
 
-- Consumer logic runs in its own container within the same pod as the main application.
-- Decouples resources. The consumer and application have their own CPU and memory limits.
-- Allows for independent scaling and focused monitoring and logging.
+- Runs in its own container within the same pod
+- Decoupled resources with independent CPU and memory limits
+- Allows independent scaling and focused monitoring
 
-3. **Standalone pod**
+3. **Standalone pod** (also used by the Kessel team)
 
-- Consumer logic runs as a completely separate deployment/service.
-- Maximum decoupling of resources, scaling, and lifecycle.
-- Highest operational complexity. Requires a separate deployment definition, monitoring, and alerting setup.
-- Can be overkill if the consumer's logic is tightly coupled to the domain of a single application.
+- Runs as a completely separate deployment
+- Maximum decoupling of resources, scaling, and lifecycle
+- Highest operational complexity with separate deployment, monitoring, and alerting
+- Can be overkill if the consumer logic is tightly coupled to a single application

--- a/src/content/docs/building-with-kessel/how-to/report-resources.mdx
+++ b/src/content/docs/building-with-kessel/how-to/report-resources.mdx
@@ -99,9 +99,9 @@ This ensures both the customer record and the outbox event are created atomicall
 
 ### Transaction IDs and Idempotency
 
-The Inventory API supports a `transaction_id` field on `ReportResourceRequest` (via `RepresentationMetadata.transaction_id`) that enables idempotent processing. If a request arrives with a `transaction_id` that has already been processed, the API skips it silently.
+The Inventory API supports a `transaction_id` field on `ReportResourceRequest` (via `ResourceRepresentations, under RepresentationMetadata.transaction_id`) that enables idempotent processing. If a request arrives with a `transaction_id` that has already been processed, the API skips it silently.
 
-For outbox-based integrations, include the `transaction_id` in your outbox event's `payload` field, since the payload mirrors the API request body.
+For outbox-based integrations, include the `transaction_id` in your outbox event's `payload` field under RepresentationMetadata, since the payload mirrors the API request body. Review the [protobuf](https://buf.build/project-kessel/inventory-api/docs/main%3Akessel.inventory.v1beta2#kessel.inventory.v1beta2.RepresentationMetadata) for more details.
 
 ### Pruning the Outbox
 
@@ -141,7 +141,7 @@ Interleaved database writes can lead to [write skew issues](https://www.cockroac
 
 ## Immediate Write Visibility with Asynchronous Messaging
 
-If you need immediate visibility of data changes but are using asynchronous event processing, consider using Postgres [LISTEN](https://www.postgresql.org/docs/current/sql-listen.html) and [NOTIFY](https://www.postgresql.org/docs/current/sql-notify.html). This lets your request handler wait for a notification about the outcome of event consumption (e.g. replication to Kessel) before returning to the client.
+If you need immediate visibility of data changes but are using asynchronous event processing, consider using Postgres [LISTEN](https://www.postgresql.org/docs/current/sql-listen.html) and [NOTIFY](https://www.postgresql.org/docs/current/sql-notify.html) in your application's database. This lets your request handler wait for a notification about the outcome of event consumption (e.g. replication to Kessel) before returning to the client. Note, this is not a Kessel feature, but a pattern you can implement in your own service.
 
 ### How it works
 


### PR DESCRIPTION
Updates:
* removes under construction banner
* all data reviewed for accuracy and pared down to make it more concise and shorter where possible (~20% reduction even with new material added)
* updates outbox examples to use more accurate payload examples that reflect an API request as required
* adds information about transaction_id availability in requests
* expands on auditing the outbox section to include logging/archiving to potentially aid in fixing inconsistencies (such as missing deletes)
* updates the code examples for consumer retry/rebalance to use more generic names and not require any knowledge of inventory code and conventions