### PR TITLE
RHCLOUD-47168: adds sdk reference under 'building with kessel' section

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -64,6 +64,7 @@ const baseStarlightConfig = {
           label: "Reference",
           collapsed: true,
           items: [
+            'building-with-kessel/reference/sdks',
             'building-with-kessel/reference/schema',
             'building-with-kessel/reference/glossary',
             {

--- a/src/content/docs/building-with-kessel/reference/sdks.mdx
+++ b/src/content/docs/building-with-kessel/reference/sdks.mdx
@@ -24,6 +24,10 @@ All SDKs use gRPC, which is Kessel's primary protocol.
 
 All SDKs follow a consistent package structure across languages. If you know one SDK, the others will feel familiar.
 
+<Aside type="note" title="Browser SDK">
+  A separate [kessel-sdk-browser](https://github.com/project-kessel/kessel-sdk-browser) exists for browser environments. It uses HTTP (not gRPC) and implements a subset of the API, primarily `CheckSelf` endpoints. It does not follow the standard SDK specification above. If you have a use case that requires browser-based access, reach out to the team for guidance.
+</Aside>
+
 ## Getting started
 
 For installation instructions and usage examples, see the getting started guide.

--- a/src/content/docs/building-with-kessel/reference/sdks.mdx
+++ b/src/content/docs/building-with-kessel/reference/sdks.mdx
@@ -1,0 +1,57 @@
+---
+title: SDKs
+description: Available Kessel SDKs, installation links, and protocol support.
+sidebar:
+  order: 0
+---
+
+import { LinkCard } from '@astrojs/starlight/components';
+import { Aside } from '@astrojs/starlight/components';
+
+Kessel provides official SDKs for multiple languages. Each SDK handles connection management, authentication, and serialization so you can focus on integrating with Kessel's APIs.
+
+gRPC is Kessel's primary protocol and the default for all SDKs. HTTP REST is supported as an alternative but does not cover all features (for example, streaming endpoints are gRPC-only). Use gRPC unless you have a specific reason not to.
+
+## Available SDKs
+
+| Language | Repository | Install from |
+|----------|-----------|-------------|
+| Go | [kessel-sdk-go](https://github.com/project-kessel/kessel-sdk-go) | `go get` |
+| Python | [kessel-sdk-py](https://github.com/project-kessel/kessel-sdk-py) | PyPI |
+| Java | [kessel-sdk-java](https://github.com/project-kessel/kessel-sdk-java) | Maven Central |
+| Node.js | [kessel-sdk-node](https://github.com/project-kessel/kessel-sdk-node) | npm |
+| Ruby | [kessel-sdk-ruby](https://github.com/project-kessel/kessel-sdk-ruby) | RubyGems |
+
+All SDKs follow a consistent package structure across languages. If you know one SDK, the others will feel familiar.
+
+## Getting started
+
+For installation instructions and usage examples, see the getting started guide.
+
+<LinkCard title="Getting started" href="/docs/start-here/getting-started/" />
+
+For CI/CD setup including native compilation and Docker builds, see the SDK CI guide.
+
+<LinkCard title="Setting up SDKs for CI" href="/docs/building-with-kessel/how-to/setup-sdk-for-ci/" />
+
+## SDK package structure
+
+Each SDK organizes its code into consistent packages:
+
+- **`{service}.{version}`** contains generated client code for a specific API (e.g. `inventory.v1beta2`). This is where you find `ClientBuilder` for creating service clients.
+- **`grpc`** contains gRPC-specific utilities like channel creation and authentication middleware.
+- **`http`** contains HTTP transport utilities for services that support REST.
+- **`middleware`** contains transport-agnostic utilities such as token caching.
+- **`rbac.v2`** contains helpers for constructing common RBAC resource types.
+- **`console`** contains helpers for ConsoleDot integration.
+
+<Aside type="note" title="For SDK contributors">
+  The full package specifications, including method signatures, interface contracts, and implementation rules, are maintained in the [Client SDK Specification](/docs/contributing/client-libraries/). If you are building or contributing to a Kessel SDK, start there.
+</Aside>
+
+## API references
+
+For the underlying API definitions that the SDKs wrap:
+
+- **gRPC API** (primary): Browse the protobuf definitions on the [Buf Schema Registry](https://buf.build/project-kessel/inventory-api/docs/main:kessel.inventory.v1beta2)
+- **HTTP REST API** (alternative): See the [OpenAPI reference](/docs/building-with-kessel/reference/http-api/). Not all gRPC features are available over HTTP.

--- a/src/content/docs/building-with-kessel/reference/sdks.mdx
+++ b/src/content/docs/building-with-kessel/reference/sdks.mdx
@@ -1,6 +1,6 @@
 ---
 title: SDKs
-description: Available Kessel SDKs, installation links, and protocol support.
+description: Available Kessel SDKs and installation links.
 sidebar:
   order: 0
 ---
@@ -10,7 +10,7 @@ import { Aside } from '@astrojs/starlight/components';
 
 Kessel provides official SDKs for multiple languages. Each SDK handles connection management, authentication, and serialization so you can focus on integrating with Kessel's APIs.
 
-gRPC is Kessel's primary protocol and the default for all SDKs. HTTP REST is supported as an alternative but does not cover all features (for example, streaming endpoints are gRPC-only). Use gRPC unless you have a specific reason not to.
+All SDKs use gRPC, which is Kessel's primary protocol.
 
 ## Available SDKs
 
@@ -40,7 +40,6 @@ Each SDK organizes its code into consistent packages:
 
 - **`{service}.{version}`** contains generated client code for a specific API (e.g. `inventory.v1beta2`). This is where you find `ClientBuilder` for creating service clients.
 - **`grpc`** contains gRPC-specific utilities like channel creation and authentication middleware.
-- **`http`** contains HTTP transport utilities for services that support REST.
 - **`middleware`** contains transport-agnostic utilities such as token caching.
 - **`rbac.v2`** contains helpers for constructing common RBAC resource types.
 - **`console`** contains helpers for ConsoleDot integration.
@@ -49,9 +48,6 @@ Each SDK organizes its code into consistent packages:
   The full package specifications, including method signatures, interface contracts, and implementation rules, are maintained in the [Client SDK Specification](/docs/contributing/client-libraries/). If you are building or contributing to a Kessel SDK, start there.
 </Aside>
 
-## API references
+## API reference
 
-For the underlying API definitions that the SDKs wrap:
-
-- **gRPC API** (primary): Browse the protobuf definitions on the [Buf Schema Registry](https://buf.build/project-kessel/inventory-api/docs/main:kessel.inventory.v1beta2)
-- **HTTP REST API** (alternative): See the [OpenAPI reference](/docs/building-with-kessel/reference/http-api/). Not all gRPC features are available over HTTP.
+For the underlying API definitions that the SDKs wrap, browse the protobuf definitions on the [Buf Schema Registry](https://buf.build/project-kessel/inventory-api/docs/main:kessel.inventory.v1beta2).

--- a/src/content/docs/contributing/client-api/http.md
+++ b/src/content/docs/contributing/client-api/http.md
@@ -5,4 +5,6 @@ docType: client-package
 
 Package for utility methods or middleware specific to HTTP (whatever the library used) and therefore coupled to that library (or language runtime), not to a specific API version.
 
+This package is reserved for future use. HTTP transport is not currently implemented in any Kessel SDK. All SDKs use gRPC.
+
 **MUST NOT** import anything from the other defined peer packages.

--- a/src/content/docs/contributing/client-libraries.mdx
+++ b/src/content/docs/contributing/client-libraries.mdx
@@ -21,9 +21,8 @@ import { Aside } from '@astrojs/starlight/components';
 
 ### Protocols
 
-- Our primary protocol is gRPC, but it is not required
-- For gRPC services, HTTP REST should be supported, but not the default, for client libraries
-  - HTTP may not support all of the features of the corresponding gRPC API, e.g. streaming endpoints.
+gRPC is the primary and currently the only supported protocol for Kessel SDKs.
+
 
 ### Client generation
 
@@ -98,7 +97,7 @@ The _suffixes_ of these imports SHOULD be consistent from language to language (
 
 - [`{prefix}.{service}.{major_version}`](../client-api/service-version): Package for code specific to service and API version, where `{service}` is the separately versioned service (e.g. "inventory" or "rbac") and `{major_version}` is the major revision of the API (e.g. v1beta2, v1, v2), such as generated client code.
 - [`{prefix}.grpc`](../client-api/grpc): Package for utility methods or middleware specific to gRPC and are therefore only coupled to gRPC versions, not to a service API version (e.g. generic gRPC authentication middleware code goes here).
-- [`{prefix}.http`](../client-api/http): Package for utility methods or middleware specific to HTTP (whatever the library used) and therefore coupled to that library (or language runtime), not to a specific API version.
+- [`{prefix}.http`](../client-api/http): Reserved for HTTP transport utilities if HTTP support is added in the future. Not currently implemented in any SDK.
 - [`{prefix}.middleware`](../client-api/middleware): Package for reusable middleware or utilities not specific to transport (e.g. gRPC) or API version.
 
 **Occasionally, a piece of code is dependent on multiple boundaries** (such as RBAC _and_ a particular API version, or gRPC _and_ a particular integration). In these cases, use some language specific means to further delineate (such as sub-packages, files, classes, etc).


### PR DESCRIPTION
Adds a new SDK section under Building with Kessel reference section to:
* highlight the existing SDKs and cross reference to existing docs
  * core audience being services looking to build their platform leveraging Kessel and who will need SDK reference material to do so 
* better align with the CIR-005 for documentation