### PR TITLE
RHCLOUD-47515: fix Java getting-started example by adding missing dependencies and updating versions

### DIFF
--- a/src/content/docs/start-here/getting-started.mdx
+++ b/src/content/docs/start-here/getting-started.mdx
@@ -281,7 +281,7 @@ We'll start by setting up a client you can use to interact with Kessel. We have 
             <dependency>
               <groupId>org.project-kessel</groupId>
               <artifactId>kessel-sdk</artifactId>
-              <version>1.6.0</version>
+              <version>1.7.0</version>
             </dependency>
             <dependency>
               <groupId>io.grpc</groupId>

--- a/src/content/docs/start-here/getting-started.mdx
+++ b/src/content/docs/start-here/getting-started.mdx
@@ -281,14 +281,27 @@ We'll start by setting up a client you can use to interact with Kessel. We have 
             <dependency>
               <groupId>org.project-kessel</groupId>
               <artifactId>kessel-sdk</artifactId>
-              <version>1.2.1</version>
+              <version>1.6.0</version>
+            </dependency>
+            <dependency>
+              <groupId>io.grpc</groupId>
+              <artifactId>grpc-netty-shaded</artifactId>
+              <version>1.77.0</version>
+              <scope>runtime</scope>
+            </dependency>
+            <dependency>
+              <groupId>com.nimbusds</groupId>
+              <artifactId>oauth2-oidc-sdk</artifactId>
+              <version>11.30.1</version>
             </dependency>
             ```
           </TabItem>
           <TabItem label="Gradle">
             ```groovy
             dependencies {
-              implementation 'org.project-kessel:kessel-sdk:1.2.1'
+              implementation 'org.project-kessel:kessel-sdk:1.6.0'
+              runtimeOnly 'io.grpc:grpc-netty-shaded:1.77.0'
+              implementation 'com.nimbusds:oauth2-oidc-sdk:11.30.1'
             }
             ```
           </TabItem>


### PR DESCRIPTION
The Java code example in the getting-started guide fails to compile when following the listed dependency instructions. 

Based on Claude assessment:
> This is because the `kessel-sdk` marks two of its own dependencies as optional in its Maven/Gradle configs but the SDK's public API (`ClientBuilder.build()`) requires types from those libraries.

This PR updates the Java Maven and Gradle instructions to include all required dependencies and bump versions:
* `kessel-sdk` bumped from `1.2.1` to `1.6.0`
* Added `grpc-netty-shaded:1.77.0` as a runtime dependency (provides the gRPC transport layer) (also mentioned in README)
* Added `oauth2-oidc-sdk:11.30.1` as a compile dependency 
* Versions are aligned with the [kessel-sdk-java README](https://github.com/project-kessel/kessel-sdk-java/blob/main/README.md).

Validated following the updated Getting Started guide with both Maven and Gradle and get the correct responses
