### PR TITLE
RHCLOUD-47516: Add dedicated public roadmap page

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -45,6 +45,7 @@ const baseStarlightConfig = {
       items: [
         "start-here/getting-started",
         "start-here/understanding-kessel",
+        "start-here/roadmap",
       ],
     },
     {

--- a/src/content/docs/start-here/getting-started.mdx
+++ b/src/content/docs/start-here/getting-started.mdx
@@ -36,7 +36,7 @@ If you are migrating an existing Red Hat Insights application to Kessel, follow 
 </Aside>
 
 <Aside type="note" title="Some assembly required">Parts of this workflow are evolving. Schema configuration, RBAC management, and the local development setup are all being simplified.
-See the [roadmap](#where-are-we-going) for details on what's changing.</Aside>
+See the [roadmap](/docs/start-here/roadmap/) for details on what's changing.</Aside>
 
 ## Quick start
 
@@ -348,7 +348,7 @@ Kessel provides several ways to handle this, including fully consistent checks (
 
 <CodeExamples files={gettingStartedExamples} />
 
-## Next steps and roadmap
+## Next steps
 
 ### Exercises
 
@@ -364,8 +364,18 @@ We're open to contributions! Check us out on GitHub at [project-kessel](https://
 
 ### Where are we going?
 
-| Feature                      | Today                                                                                       | What's Next                                                                                        |
-|------------------------------|---------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------|
-| **Schema Language**          | Resource attributes (JSON config) and permissions (KSL) use separate files                  | Unified schema language that combines attributes and permissions                                   |
-| **Configuration Method**     | Edit schema and config via files                                                            | Configure everything at runtime via an API                                                         |
-| **RBAC Management**          | Use temporary scripts or the pre-Kessel RBAC v1 API                                         | Use an RBAC management API (v2) to encapsulate access grants and workspace management              |
+Several parts of this workflow — schema configuration, RBAC management, and local development setup — are actively being simplified. See the full roadmap for details.
+
+<LinkButton href="/docs/start-here/roadmap/" icon="right-arrow" variant="secondary">View the Kessel roadmap</LinkButton>
+
+### Feedback
+
+Have a use case or gap you'd like to see addressed? Open an RFE. Found a bug? Report it to the team.
+
+<LinkButton href="https://redhat.atlassian.net/jira/software/c/projects/RHCLOUD/form/465" icon="external" variant="secondary">
+  Request a feature (RFE)
+</LinkButton>
+
+<LinkButton href="https://redhat.atlassian.net/jira/software/c/projects/RHCLOUD/form/501" icon="external" variant="secondary">
+  Report a bug
+</LinkButton>

--- a/src/content/docs/start-here/roadmap.mdx
+++ b/src/content/docs/start-here/roadmap.mdx
@@ -1,0 +1,80 @@
+---
+title: Roadmap
+description: Where Kessel is today, what's actively in development, and what's on the longer horizon.
+---
+
+import { Aside, Badge, Card, CardGrid, LinkButton, LinkCard } from '@astrojs/starlight/components';
+
+This page describes Kessel's **Now / Next / Later** roadmap — the current state of the platform,
+what's actively in development, and what we're working toward.
+
+<Aside type="tip" title="Links">
+- **Internal Red Hat view** — [Jira roadmap plan](https://redhat.atlassian.net/jira/plans/3370/scenarios/3372/timeline?vid=3981) (Red Hat SSO required)
+- **Contribute or track issues** — [project-kessel on GitHub](https://github.com/project-kessel)
+</Aside>
+
+---
+
+## <Badge text="Now" variant="success" /> What's available today
+
+Features that are stable and available in the current release.
+
+<CardGrid>
+  <LinkCard title="Inventory API" href="/docs/building-with-kessel/how-to/report-resources/" description="Report, query, and track resources and their relationships via gRPC and HTTP APIs." />
+  <LinkCard title="RBAC v2" href="/docs/building-with-kessel/concepts/rbac/" description="Workspace-based tenancy with role bindings — map users or groups to roles scoped to a workspace or resource." />
+  <LinkCard title="KSL Schema Language" href="/docs/building-with-kessel/reference/schema/" description="Define resource types and permissions in KSL. Compile to SpiceDB schema with the ksl compiler." />
+  <LinkCard title="Multi-reporter resources" href="/docs/building-with-kessel/concepts/resources-representations/" description="Multiple services (reporters) can share ownership of a resource, each contributing their own representation." />
+  <LinkCard title="SDKs" href="/docs/building-with-kessel/reference/sdks/" description="Client libraries for Python, Go, TypeScript, Ruby, and Java." />
+  <LinkCard title="CloudEvents via Kafka" href="/docs/building-with-kessel/concepts/events/" description="Resource changes are published as CloudEvents to Kafka, enabling event-driven integrations." />
+</CardGrid>
+
+---
+
+## <Badge text="Next" variant="caution" /> Actively in development
+
+These are in progress and targeted for upcoming releases. Some may be available in preview.
+
+<CardGrid>
+  <Card title="Unified schema language">
+    Today, resource attributes (JSON config) and permissions (KSL) use separate files.
+    A single, unified schema language will combine both into one file with a single workflow.
+  </Card>
+  <Card title="RBAC Management API v2">
+    Roles and workspaces are currently managed with temporary gRPCurl scripts.
+    An RBAC management API (v2) will provide a proper interface for access grants and workspace management.
+  </Card>
+  <Card title="Runtime schema configuration">
+    Schema is currently configured by editing files and restarting services.
+    A configuration API will allow updating schema at runtime without downtime.
+  </Card>
+</CardGrid>
+
+---
+
+## <Badge text="Later" variant="note" /> On the horizon
+
+Longer-term investments. Scope and timing are subject to change.
+
+<Aside type="note">
+This section is updated periodically. For the most current view of planned work, see the
+[Jira roadmap](https://redhat.atlassian.net/jira/plans/3370/scenarios/3372/timeline?vid=3981)
+(Red Hat internal) or watch the [project-kessel](https://github.com/project-kessel) GitHub organization for new issues and milestones.
+</Aside>
+
+- [History API](/docs/building-with-kessel/concepts/history/) — query the full change history of any resource over time
+- Enhanced multi-tenancy primitives for complex B2B and sub-tenant hierarchies
+- Additional SDK languages and improved SDK ergonomics
+
+---
+
+## Suggest something
+
+Have a use case or gap you'd like to see addressed? Open an RFE. Found a bug? Report it to the team.
+
+<LinkButton href="https://redhat.atlassian.net/jira/software/c/projects/RHCLOUD/form/465" icon="external" variant="secondary">
+  Request a feature (RFE)
+</LinkButton>
+
+<LinkButton href="https://redhat.atlassian.net/jira/software/c/projects/RHCLOUD/form/501" icon="external" variant="secondary">
+  Report a bug
+</LinkButton>


### PR DESCRIPTION
## Summary

- Adds `src/content/docs/start-here/roadmap.mdx` — a dedicated **Now / Next / Later** roadmap page using Starlight `LinkCard` and `Card` components. "Now" items deep-link to their corresponding concept and how-to pages in the docs.
- Removes the stale inline table from `getting-started.mdx` and replaces it with a brief callout + link to the new roadmap page, keeping the tutorial focused.
- Adds Jira RFE and bug report form links to both the roadmap and getting-started pages.
- Registers the roadmap page in the **Start Here** sidebar (`astro.config.mjs`).

Closes RHCLOUD-47516.

## Why

The previous inline table in the getting-started guide required manual quarterly updates and was prone to going stale. A dedicated roadmap page is easier to maintain (one place to update) and scales better as the roadmap grows. Links to the internal Jira plan are also included for Red Hat contributors.

## Test plan

- [x] `npx astro check` passes with 0 errors
- [x] Roadmap page renders at `/docs/start-here/roadmap/` with Now/Next/Later sections
- [x] All "Now" cards are clickable links to their docs pages
- [x] "Suggest something" buttons link to the correct Jira forms
- [x] Getting started page no longer contains the old roadmap table
- [x] Roadmap appears in the Start Here sidebar

Made with [Cursor](https://cursor.com)