### PR TITLE
RHCLOUD-47183: add/improve monitoring guides with KPIs, metrics, and example alerting queries

### DIFF
--- a/src/content/docs/running-kessel/monitoring-kessel/monitoring-data-replication-inventory-api.mdx
+++ b/src/content/docs/running-kessel/monitoring-kessel/monitoring-data-replication-inventory-api.mdx
@@ -5,13 +5,18 @@ sidebar:
   order: 20
 ---
 
-import { Aside } from '@astrojs/starlight/components';
+import { Aside, LinkCard } from '@astrojs/starlight/components';
 
 ## How Inventory API Ensures Data Consistency
 
-Inventory API uses [Change Data Capture](https://www.geeksforgeeks.org/change-data-capture-cdc/) (CDC) and the [Outbox Pattern](https://www.geeksforgeeks.org/outbox-pattern-for-reliable-messaging-system-design/) to ensure internal data consistency and reliable replication of relationship changes to SpiceDB. [Debezium](https://debezium.io/) monitors an outbox table in the Inventory API database and publishes change events to a Kafka topic. A Kafka consumer embedded in the Inventory API service processes those events and replicates the corresponding relationships to SpiceDB. Because events are ordered, they are processed sequentially, preventing inconsistencies from concurrent updates or failures.
+Inventory API uses [Change Data Capture](https://www.geeksforgeeks.org/change-data-capture-cdc/) (CDC) to ensure internal data consistency and reliable replication of relationship changes to SpiceDB. Within each database transaction, the service writes an event using PostgreSQL [logical decoding messages](https://www.postgresql.org/docs/current/functions-admin.html#id-1.5.8.32.8.3.2.2.12.1.1.1) (`pg_logical_emit_message`). [Debezium](https://debezium.io/) captures these messages from the write-ahead log (WAL) and publishes them to a Kafka topic. A Kafka consumer embedded in the Inventory API service processes those events and replicates the corresponding relationships to SpiceDB. Because events are ordered, they are processed sequentially, preventing inconsistencies from concurrent updates or failures.
 
-If your service is planning to integrate with Kessel Inventory, CDC with the outbox pattern is an effective way to ensure reliable replication. This guide covers the key metrics to monitor and example queries for alerting, which apply to any service using a similar Kafka and Debezium-based replication flow.
+This guide covers the key metrics and example alerting queries for monitoring this CDC pipeline. The same patterns apply to any service using a similar Kafka and Debezium-based replication flow.
+
+<Aside type="tip">
+  If you are looking to report resources to Kessel using your own CDC or async messaging pipeline, see the reporting guide for implementation strategies.
+  <LinkCard title="Report resources" href="/docs/building-with-kessel/how-to/report-resources/" />
+</Aside>
 
 ## Key Performance Indicators (KPIs)
 
@@ -33,7 +38,7 @@ Consumer lag is the difference between the latest offset stored by the broker an
 
 ### End-to-End Lag
 
-End-to-end lag captures the time between when an event is written to the outbox table and when the consumer processes and commits it. This measures the full CDC/outbox pipeline latency, including Debezium capture time, Kafka delivery, and consumer processing.
+End-to-end lag captures the time between when an event is emitted as a logical decoding message and when the consumer processes and commits it. This measures the full CDC pipeline latency, including Debezium capture time, Kafka delivery, and consumer processing.
 
 ## Metrics Sources
 
@@ -49,17 +54,19 @@ Kafka Connect clusters (where the Debezium connector runs) can expose metrics vi
 
 ### Custom Application Metrics
 
-Kafka infrastructure metrics alone do not indicate how well your application is processing events. The following custom metrics fill that gap. We recommend these names as a convention so that teams using similar CDC/outbox setups can share alerting configurations.
+Kafka infrastructure metrics alone do not indicate how well your application is processing events. The following custom metrics fill that gap.
+
+Inventory API uses two metric prefixes: `consumer_` for consumer-related metrics and `kessel_inventory_` for general application metrics. Counter metrics include the `_total` suffix added by the metrics framework.
 
 **Custom metrics:**
 
-| Metric name | Type | Description |
-|-------------|------|-------------|
-| `consumer_msgs_processed_total` | Counter | Events consumed, processed by the application, and committed as complete |
-| `consumer_msg_process_failures_total` | Counter | Events that failed during application processing |
-| `consumer_errors_total` | Counter | Consumer client errors (connection failures, broker issues) |
-| `consumer_kafka_error_events_total` | Counter | Kafka error events consumed from the broker |
-| `outbox_event_writes_total` | Counter | Events written to the outbox table (used for end-to-end lag calculation) |
+| Metric name | Scope/Prefix | Type | Description |
+|-------------|--------------|------|-------------|
+| `consumer_msgs_processed_total` | `consumer_` | Counter | Events consumed, processed by the application, and committed as complete |
+| `consumer_msg_process_failures_total` | `consumer_` | Counter | Events that failed during application processing |
+| `consumer_consumer_errors_total` | `consumer_` | Counter | Consumer client errors (connection failures, broker issues) |
+| `consumer_kafka_error_events_total` | `consumer_` | Counter | Kafka error events consumed from the broker |
+| `kessel_inventory_outbox_event_writes_total` | `kessel_inventory_` | Counter | Outbox events emitted as logical decoding messages (used for end-to-end lag calculation) |
 
 **Kafka infrastructure metrics:**
 
@@ -69,7 +76,7 @@ Kafka infrastructure metrics alone do not indicate how well your application is 
 
 **librdkafka statistics metrics:**
 
-librdkafka statistics metrics are predefined by Kafka but have generic names. We recommend using a `consumer_stats_` prefix to distinguish them from other metrics in your service.
+librdkafka statistics metrics are predefined by Kafka but have generic names. Inventory API uses the `consumer_stats_` prefix to distinguish them from other metrics.
 
 For example, the `replyq` statistic becomes `consumer_stats_replyq`. The `consumer_lag` statistic (available per topic-partition) becomes `consumer_stats_consumer_lag` and is the recommended source for consumer lag alerting.
 
@@ -96,7 +103,7 @@ Alert when the failure rate exceeds a threshold over a given window:
 Alert on a sustained increase in consumer client errors:
 
 ```promql
-rate(consumer_errors_total{job="my-service"}[5m]) > 0
+rate(consumer_consumer_errors_total{job="my-service"}[5m]) > 0
 ```
 
 ### Kafka error rate
@@ -137,6 +144,6 @@ The consumer is falling behind event production. Check consumer error rates and 
 
 The Debezium connector has failed or paused. Check connector task status and logs for errors. Common causes include database connectivity issues, replication slot problems, or schema changes that the connector cannot handle. See [Database changes with a Debezium source connector](/docs/running-kessel/monitoring-kessel/monitoring-data-replication-inventory-api/) for connector recovery guidance.
 
-### Outbox writes with no consumer processing
+### Outbox events emitted with no consumer processing
 
-Events are being written to the outbox table but are not being consumed. This usually means either the connector is not capturing changes (check connector health first) or the consumer is not running. Verify that the connector is active and that the consumer pods are healthy.
+Events are being written to the WAL but are not being consumed. This usually means either the Debezium connector is not capturing logical decoding messages (check connector health first) or the consumer is not running. Verify that the connector is active and that the consumer pods are healthy.

--- a/src/content/docs/running-kessel/monitoring-kessel/monitoring-data-replication-inventory-api.mdx
+++ b/src/content/docs/running-kessel/monitoring-kessel/monitoring-data-replication-inventory-api.mdx
@@ -1,70 +1,142 @@
 ---
 title: "Monitoring Data Replication in Inventory API"
-description: "Metrics, Monitoring, and Alerting methods for Data Replication in Inventory API"
+description: "Metrics, monitoring, and alerting for data replication in Inventory API"
+sidebar:
+  order: 20
 ---
+
+import { Aside } from '@astrojs/starlight/components';
 
 ## How Inventory API Ensures Data Consistency
 
-Inventory API uses a combination of [CDC](https://www.geeksforgeeks.org/change-data-capture-cdc/) and the [Outbox Pattern](https://www.geeksforgeeks.org/outbox-pattern-for-reliable-messaging-system-design/) to ensure internal data consistency, as well as consistent replication of Relations changes to SpiceDB. It does so by leveraging [Streams for Apache Kafka](https://developers.redhat.com/products/streams-for-apache-kafka/overview) and [Debezium](https://debezium.io/) to monitor changes in an outbox table in the Inventory API's database, and publish those events to a Kafka Topic. The events are then consumed by a Kafka Consumer client embedded in the Inventory API service, which handles creating or replicating changes to Relationships defined in SpiceDB for the given resource. Since events are ordered, they are processed in order, ensuring concurrent resource updates or failures do not create inconsistencies between Inventory and SpiceDB.
+Inventory API uses [Change Data Capture](https://www.geeksforgeeks.org/change-data-capture-cdc/) (CDC) and the [Outbox Pattern](https://www.geeksforgeeks.org/outbox-pattern-for-reliable-messaging-system-design/) to ensure internal data consistency and reliable replication of relationship changes to SpiceDB. [Debezium](https://debezium.io/) monitors an outbox table in the Inventory API database and publishes change events to a Kafka topic. A Kafka consumer embedded in the Inventory API service processes those events and replicates the corresponding relationships to SpiceDB. Because events are ordered, they are processed sequentially, preventing inconsistencies from concurrent updates or failures.
 
-The processes to ensure consistency means the addition of critical KPI's to monitor to ensure a stable and reliable service. For services that are planning to integrate with Kessel Inventory, the CDC/Outbox Pattern is an excellent way to ensure replication of changes to Inventory API. If you are looking to embark on your own CDC/Outbox journey, this guide should provide a good primer on the monitoring components critical to data consistency and replication between other services.
+If your service is planning to integrate with Kessel Inventory, CDC with the outbox pattern is an effective way to ensure reliable replication. This guide covers the key metrics to monitor and example queries for alerting, which apply to any service using a similar Kafka and Debezium-based replication flow.
 
 ## Key Performance Indicators (KPIs)
 
-Below are some of the key metrics we monitor to ensure consistency and replication aspects of Inventory API are functioning and healthy. This data is aggregated from a few data sources, including custom metrics defined in our service. Those leveraging a similar pattern using Kafka and Debezium would also benefit from monitoring these critical metrics.
+### Message Processing Failure Rate
 
-#### Message Processing Failure Rate:
+The ratio of failed message processing attempts to total messages processed. A processed message is one that has been consumed from Kafka, handled by the application, and committed as complete. A sustained increase in the failure rate indicates the consumer is unable to process events, which means data replication is not occurring.
 
-We compare the number of messages processed by Inventory API to the number of message processing errors to determine our failure rate. Note that processed messages are not just messages consumed from Kafka, but are processed by the application and then committed with Kafka as completed.
+### Consumer Error Rate
 
-#### Consumer Error Rate:
+Consumer errors are failures in the consumer client itself, such as the inability to connect to or interact with the Kafka broker. A growing error rate means the consumer cannot receive messages, which directly blocks data replication.
 
-Consumer Errors are errors related to the function of the Consumer client itself and its ability to interact with the Kafka broker. We monitor the rate of Consumer errors for higher-than-normal growth to ensure we are aware when the consumer client cannot process messages. When the consumer cannot process events, data replication is not occurring which could impact services/users relying on those changes.
+### Kafka Error Rate
 
-#### Kafka Error Rate:
+Kafka publishes errors related to brokers and related components as events. Monitoring the rate of these error events helps surface infrastructure issues that affect event delivery and data replication.
 
-Kafka will publish errors related to the broker or interrelated components as events. We monitor the increase in Kafka error messages for the same reason we monitor consumer errors as it has direct impact on data replication.
+### Consumer Lag
 
-#### Consumer Lag and End-to-End Lag:
+Consumer lag is the difference between the latest offset stored by the broker and the last committed offset for a given partition. Lag can result from network issues, slow event processing, processing errors, or Kafka infrastructure problems. It is a critical metric for understanding replication performance and knowing when to scale components or investigate issues.
 
-Consumer lag is the difference between the last offset stored by the broker and the last committed offset for that partition. Lag can occur for a few reasons: network congestion, slow processing of events, errors in processing events, or Kafka-related errors to address are just some examples. Its a critical metric for understanding the performance of your data replication and knowing when problems arise or when its time to scale these components to keep up with the number of events to process.
+### End-to-End Lag
 
-End-to-End Lag takes this a step further and captures the gap between when events are written to the outbox table to the consumer processing and committing the event. The goal here being to capture if there are any bottle necks in the entire CDC/Outbox flow from start to finish.
+End-to-end lag captures the time between when an event is written to the outbox table and when the consumer processes and commits it. This measures the full CDC/outbox pipeline latency, including Debezium capture time, Kafka delivery, and consumer processing.
 
 ## Metrics Sources
 
-Inventory API leverages the following data sources for monitoring various components of the consistency flow. These metrics are aggregated into Prometheus for monitoring using Grafana for dashboards and alerting through Alertmanager.
-
 ### librdkafka Internal Metrics
 
-librdkafka is a C library implementation of the Apache Kafka protocol, providing Producer, Consumer and Admin clients in numerous [languages](https://github.com/confluentinc/librdkafka/tree/master?tab=readme-ov-file#language-bindings). librdkafka-based clients can be configured to emit [internal metrics](https://github.com/confluentinc/librdkafka/blob/master/STATISTICS.md) as events, in which a service can capture and record these metrics in an external monitoring service, such as Prometheus.
+[librdkafka](https://github.com/confluentinc/librdkafka) is a C library implementation of the Apache Kafka protocol, providing Producer, Consumer, and Admin clients in numerous [languages](https://github.com/confluentinc/librdkafka/tree/master?tab=readme-ov-file#language-bindings). librdkafka-based clients can be configured to emit [internal metrics](https://github.com/confluentinc/librdkafka/blob/master/STATISTICS.md) as events, which a service can capture and export to a monitoring system like Prometheus.
 
-Inventory API leverages the Statistics metrics from our Kafka Consumer client to capture metrics on the client itself, as well as Kafka related components the client interacts with (topics, brokers, consumer groups, etc).
+Inventory API uses librdkafka statistics from the Kafka consumer to track client health, topic state, broker connectivity, and consumer group behavior.
 
-### Streams for Apache Kafka Prometheus Configuration
+### Kafka Connect / JMX Exporter
 
-Streams for Apache Kafka can be [configured to expose metrics](https://docs.redhat.com/en/documentation/red_hat_streams_for_apache_kafka/2.9/html/deploying_and_managing_streams_for_apache_kafka_on_openshift/assembly-metrics-str#proc-metrics-kafka-deploy-options-str) for various Kafka related components, including the Kafka Connect cluster (where the Debezium connector runs) using the Prometheus JMX Exporter. These metrics provide more in-depth data about the Kafka infrastructure that we rely on as part of the CDC/Outbox pattern flow.
+Kafka Connect clusters (where the Debezium connector runs) can expose metrics via the [Prometheus JMX Exporter](https://github.com/prometheus/jmx_exporter). These metrics provide visibility into connector status, task health, and throughput.
 
-Inventory API leverages Kafka Connect related metrics to understand the state of our Debezium connector and monitor its health.
+### Custom Application Metrics
 
-### Kafka Lag Exporter
+Kafka infrastructure metrics alone do not indicate how well your application is processing events. The following custom metrics fill that gap. We recommend these names as a convention so that teams using similar CDC/outbox setups can share alerting configurations.
 
-The [Kafka Lag Exporter](https://docs.redhat.com/en/documentation/red_hat_streams_for_apache_kafka/2.9/html/deploying_and_managing_streams_for_apache_kafka_on_openshift/assembly-metrics-str#con-metrics-kafka-exporter-lag-str) extracts additional metrics data from Kafka brokers related to offsets, consumer groups, consumer lag, and topics. It can also be configured through Streams for Apache Kafka and offers supplemental data similar to the librdkafka metrics.
+**Custom metrics:**
 
-Inventory API leverages the Kafka Lag exporter to monitor lag between our consumer client process and message queue.
+| Metric name | Type | Description |
+|-------------|------|-------------|
+| `consumer_msgs_processed_total` | Counter | Events consumed, processed by the application, and committed as complete |
+| `consumer_msg_process_failures_total` | Counter | Events that failed during application processing |
+| `consumer_errors_total` | Counter | Consumer client errors (connection failures, broker issues) |
+| `consumer_kafka_error_events_total` | Counter | Kafka error events consumed from the broker |
+| `outbox_event_writes_total` | Counter | Events written to the outbox table (used for end-to-end lag calculation) |
 
-### Custom Metrics
+**Kafka infrastructure metrics:**
 
-While there is no shortage of ways to get metrics data from Kafka-related services, none are indicators of how your service is functioning with regards to publishing and processing events to ensure consistency and replication. Below are the custom metrics we have defined that help fill in the gaps.
+| Metric name | Type | Source | Description |
+|-------------|------|--------|-------------|
+| `kafka_connect_connector_status` | Gauge | JMX Exporter | Connector status (running, paused, failed) |
 
-* **Messages Processed**: Counter that tracks events that are consumed and processed by the application and committed as completed. Used as part of capturing message processing failure rate
-* **Message Process Failures**: Counter to track whenever processing a message fails for any reason. Used as part of capturing message processing failure rate
-* **Consumer Errors**: Counter to track when the Consumer client fails for any reason. Used to calculate consumer error rates.
-* **Kafka Error Events**: Counter to track whenever a Kafka Error event is consumed for any reason. Used to calculate kafka error rates.
-* **Outbox Event Writes**: Counter to track when an event is written to the outbox table. Used for calculating end-to-end lag.
+**librdkafka statistics metrics:**
 
-## Alerting
+librdkafka statistics metrics are predefined by Kafka but have generic names. We recommend using a `consumer_stats_` prefix to distinguish them from other metrics in your service.
 
-Our alerting strategy for monitoring data consistency and replication is to ensure our alerts directly align with our KPI's, plus some platform related monitoring (Database disk usage, Kubernetes metrics, etc).
+For example, the `replyq` statistic becomes `consumer_stats_replyq`. The `consumer_lag` statistic (available per topic-partition) becomes `consumer_stats_consumer_lag` and is the recommended source for consumer lag alerting.
 
-For Red Hat Service Provider teams implementing a similar CDC/Outbox setup, the Kessel team can provide some resources, templates, and tooling that may simplify some of this monitoring work for you. See our [Internal Guide](https://project-kessel.pages.redhat.com/docs-internal/running-kessel/monitoring-kessel/monitoring-data-replication-inventory-api/) for more info (requires Red Hat VPN to access).
+See the [librdkafka statistics documentation](https://github.com/confluentinc/librdkafka/blob/master/STATISTICS.md) for the full list of available metrics.
+
+## Example Alerting Queries
+
+The following PromQL queries correspond to the KPIs above. Adjust thresholds and time windows to match your service's expected traffic patterns. The `job` label filters to your service's specific metrics (set by your Prometheus scrape configuration or ServiceMonitor).
+
+### Message processing failure rate
+
+Alert when the failure rate exceeds a threshold over a given window:
+
+```promql
+(
+  rate(consumer_msg_process_failures_total{job="my-service"}[5m])
+  /
+  rate(consumer_msgs_processed_total{job="my-service"}[5m])
+) > 0.05
+```
+
+### Consumer error rate
+
+Alert on a sustained increase in consumer client errors:
+
+```promql
+rate(consumer_errors_total{job="my-service"}[5m]) > 0
+```
+
+### Kafka error rate
+
+Alert on Kafka error events:
+
+```promql
+rate(consumer_kafka_error_events_total{job="my-service"}[5m]) > 0
+```
+
+### Consumer lag
+
+Alert when the consumer falls behind the topic by more than a threshold number of messages. This uses the `consumer_lag` statistic from librdkafka:
+
+```promql
+consumer_stats_consumer_lag{job="my-service"} > 1000
+```
+
+### Connector health
+
+Alert when the Debezium connector is not in a running state:
+
+```promql
+kafka_connect_connector_status{connector="my-debezium-connector"} != 1
+```
+
+<Aside type="note">
+  These queries are examples to get you started. In practice, you may want to add `for` durations to avoid alerting on brief spikes, use `absent()` to detect missing metrics, or combine multiple conditions.
+</Aside>
+
+## Troubleshooting
+
+### Consumer lag is increasing
+
+The consumer is falling behind event production. Check consumer error rates and processing times. Common causes include slow downstream services (e.g., SpiceDB latency), resource constraints on the consumer pod, or network issues between the consumer and the Kafka broker.
+
+### Connector status is unhealthy
+
+The Debezium connector has failed or paused. Check connector task status and logs for errors. Common causes include database connectivity issues, replication slot problems, or schema changes that the connector cannot handle. See [Database changes with a Debezium source connector](/docs/running-kessel/monitoring-kessel/monitoring-data-replication-inventory-api/) for connector recovery guidance.
+
+### Outbox writes with no consumer processing
+
+Events are being written to the outbox table but are not being consumed. This usually means either the connector is not capturing changes (check connector health first) or the consumer is not running. Verify that the connector is active and that the consumer pods are healthy.

--- a/src/content/docs/running-kessel/monitoring-kessel/monitoring-kessel-services.mdx
+++ b/src/content/docs/running-kessel/monitoring-kessel/monitoring-kessel-services.mdx
@@ -1,0 +1,243 @@
+---
+title: "Monitoring Kessel Services"
+description: "Key performance indicators, metrics, and example alerting queries for monitoring the Kessel Inventory API."
+sidebar:
+  order: 10
+---
+
+import { Aside, LinkCard } from '@astrojs/starlight/components';
+
+This guide covers the key metrics and alerting strategies for monitoring the Kessel Inventory API. It is intended for operators running Kessel and focuses on API health, latency, and streaming performance; typical of standard SLI/SLO monitoring by SRE teams. For monitoring the CDC/outbox data replication pipeline specifically, see the dedicated guide:
+
+<LinkCard title="Monitoring Data Replication" href="/docs/running-kessel/monitoring-kessel/monitoring-data-replication-inventory-api/" />
+
+## Key Performance Indicators
+
+### API Availability
+
+Availability is measured as the ratio of successful responses to total requests. Monitoring availability over both long windows (days/weeks for SLO tracking) and short windows (minutes for spike detection) gives you a complete picture.
+
+Track availability at two levels:
+- **Service-wide**: The overall error rate across all operations. A sustained increase here means the service is broadly unhealthy.
+- **Per-operation**: Error rates broken down by gRPC method. This helps identify whether a single endpoint is failing while the rest of the service is healthy.
+
+Client errors (4xx/gRPC codes like `NotFound`, `PermissionDenied`, `Unauthenticated`) are worth monitoring separately. A sudden increase in 4xx errors can indicate auth misconfigurations, permission changes, or clients sending malformed requests.
+
+### API Latency
+
+Latency is tracked using request duration histograms. The most useful views are:
+
+- **Percentiles (p95, p99)**: How long the slowest requests take. A p99 spike may not affect most users but can indicate resource contention or slow queries.
+- **Percentage below a target**: What fraction of requests complete within an acceptable time (e.g., 250ms). This is useful for SLO tracking.
+- **Per-operation latency**: Some operations (like `Check`) should be fast, while others (like `StreamedListObjects`) may naturally take longer. Track them separately to set appropriate thresholds.
+
+### Streaming Performance
+
+Kessel supports gRPC streaming for operations like `StreamedListObjects` and `StreamedListSubjects`. Streaming has different performance characteristics than unary calls:
+
+- **Stream error rate**: The ratio of failed streams to total streams. A failed stream means the client received an error before or during data delivery.
+- **First-response latency**: The time between when a client opens a stream and when the first result arrives. This is the most important latency metric for streaming, since it determines how quickly a user sees initial results.
+- **Message throughput**: The rate of individual messages sent within streams. A drop in throughput may indicate backend slowdowns.
+
+### Service Health
+
+Beyond API-level metrics, monitor the underlying service health:
+
+- **Pod availability**: Whether service pods are up and responding to health checks.
+- **Resource usage**: CPU and memory consumption. Rising resource usage can predict performance degradation before it affects users.
+- **Go runtime**: Goroutine count and garbage collection pause times. A growing goroutine count may indicate leaked connections or stuck requests. Long GC pauses can cause latency spikes.
+
+## Metrics Reference
+
+The Inventory API exposes metrics through Prometheus. The tables below list the key metrics available.
+
+### Request metrics
+
+These are exposed through the [Go Kratos](https://go-kratos.dev/) middleware.
+
+| Metric | Type | Labels | Description |
+|--------|------|--------|-------------|
+| `server_requests_code_total` | Counter | `operation`, `code`, `kind` | Total requests by gRPC method, response code, and transport type |
+| `server_requests_seconds_bucket` | Histogram | `operation`, `le` | Request duration distribution with configurable bucket boundaries |
+
+### Streaming metrics
+
+These track gRPC streaming endpoint performance.
+
+| Metric | Type | Labels | Description |
+|--------|------|--------|-------------|
+| `grpc_server_streams_total` | Counter | `operation`, `code` | Total stream connections by method and response code |
+| `grpc_server_stream_first_response_duration_seconds` | Histogram | `operation`, `le` | Time from stream open to first message sent |
+| `grpc_server_stream_messages_total` | Counter | `operation` | Total individual messages sent within streams |
+| `grpc_server_stream_message_duration_seconds` | Histogram | `operation`, `le` | Duration of individual message send/receive within a stream |
+
+### Business metrics
+
+These track resource inventory state.
+
+| Metric | Type | Labels | Description |
+|--------|------|--------|-------------|
+| `kessel_inventory_resource_count` | Gauge | `resource_type`, `reporter_name`, `reporter_id` | Number of resources by type and reporter |
+| `kessel_inventory_resources_per_workspace` | Histogram | `resource_type` | Distribution of resource counts per workspace |
+
+### Operational metrics
+
+| Metric | Type | Description |
+|--------|------|-------------|
+| `kessel_inventory_serialization_failures` | Counter | Database serialization conflicts (retried automatically) |
+| `kessel_inventory_serialization_exhaustions` | Counter | Serialization conflicts that exceeded the retry limit |
+
+## Recording Rules
+
+Health check endpoints (`GetLivez`, `GetReadyz`) and reflection services (`ServerReflectionInfo`) generate constant traffic that skews availability and latency calculations. Create recording rules to filter them out before computing SLOs.
+
+**Example recording rule for request metrics:**
+
+```yaml
+groups:
+  - name: kessel-inventory-api-recording-rules
+    rules:
+      - record: kessel_inventory_api:server_requests_code_total:filtered
+        expr: >
+          server_requests_code_total{
+            job="kessel-inventory-api",
+            operation!~".*(GetLivez|GetReadyz|ServerReflectionInfo).*"
+          }
+```
+
+**Example recording rule for streaming metrics:**
+
+```yaml
+      - record: kessel_inventory_api:grpc_server_streams_total:filtered
+        expr: >
+          grpc_server_streams_total{
+            job="kessel-inventory-api",
+            operation!~".*(GetLivez|GetReadyz|ServerReflectionInfo).*"
+          }
+```
+
+Use these filtered metrics in your alerting queries instead of the raw metrics.
+
+## Example Alerting Queries
+
+The following queries correspond to the KPIs above. Adjust thresholds and time windows to match your deployment. Replace `my-service` with your service's job label.
+
+### Service availability (long window)
+
+Track the error rate over a rolling window for SLO compliance. This example alerts if more than 1% of requests are errors over 28 days:
+
+```promql
+(
+  sum(increase(kessel_inventory_api:server_requests_code_total:filtered{code=~"5..|14"}[28d]))
+  /
+  sum(increase(kessel_inventory_api:server_requests_code_total:filtered[28d]))
+) > 0.01
+```
+
+### Per-operation availability
+
+Identify specific endpoints that are failing:
+
+```promql
+(
+  sum by (operation) (increase(kessel_inventory_api:server_requests_code_total:filtered{code=~"5..|14"}[28d]))
+  /
+  sum by (operation) (increase(kessel_inventory_api:server_requests_code_total:filtered[28d]))
+) > 0.01
+```
+
+### 5xx error rate spike
+
+Catch short-term error spikes before they affect the long-window SLO:
+
+```promql
+(
+  sum(rate(kessel_inventory_api:server_requests_code_total:filtered{code=~"5..|14"}[5m]))
+  /
+  sum(rate(kessel_inventory_api:server_requests_code_total:filtered[5m]))
+) > 0.05
+```
+
+### 4xx error rate increase
+
+Detect a sudden increase in client errors:
+
+```promql
+(
+  rate(server_requests_code_total{job="my-service", code=~"401|403|404|408|409|429"}[5m])
+  /
+  rate(server_requests_code_total{job="my-service"}[5m])
+) > 0.10
+```
+
+### Latency SLO
+
+Alert when fewer than 95% of requests complete within a target latency (e.g., 250ms):
+
+```promql
+(
+  sum(rate(server_requests_seconds_bucket{job="my-service", le="0.25"}[5m]))
+  /
+  sum(rate(server_requests_seconds_bucket{job="my-service", le="+Inf"}[5m]))
+) < 0.95
+```
+
+### Stream availability
+
+Track error rates for streaming operations:
+
+```promql
+(
+  sum(increase(kessel_inventory_api:grpc_server_streams_total:filtered{code=~"5..|14"}[28d]))
+  /
+  sum(increase(kessel_inventory_api:grpc_server_streams_total:filtered[28d]))
+) > 0.01
+```
+
+### Stream first-response latency
+
+Alert when the 95th percentile of time-to-first-response exceeds a threshold:
+
+```promql
+histogram_quantile(0.95,
+  sum(rate(grpc_server_stream_first_response_duration_seconds_bucket{job="my-service"}[5m])) by (le)
+) > 1.0
+```
+
+<Aside type="note">
+  These queries are starting points. In practice, you may want to add `for` durations to avoid alerting on brief spikes, use multi-window burn rates for SLO alerting, or combine multiple conditions. See the [Google SRE workbook on alerting](https://sre.google/workbook/alerting-on-slos/) for more on SLO-based alerting strategies.
+</Aside>
+
+## Troubleshooting
+
+### High error rate across all operations
+
+The service is returning errors broadly. Check:
+- Database connectivity (PostgreSQL for inventory data, SpiceDB for authorization)
+- Resource pressure (CPU/memory limits causing OOM kills or throttling)
+- Upstream dependency failures (SpiceDB, Kafka)
+- Recent deployments or configuration changes
+
+### High error rate on a single operation
+
+One endpoint is failing while others work. Check:
+- Whether the operation depends on a specific backend that may be down
+- Whether request payloads for that operation have changed (schema validation failures)
+- Whether the operation is a streaming endpoint hitting timeout limits
+
+### Latency spikes
+
+Requests are succeeding but taking longer than expected. Check:
+- Database query performance (slow queries, lock contention)
+- SpiceDB response times for permission checks
+- Garbage collection pause times (Go runtime)
+- Pod resource limits (CPU throttling)
+- Network latency between services
+
+### Serialization exhaustions
+
+The `kessel_inventory_serialization_exhaustions` counter is increasing. This means concurrent requests are conflicting on the same database rows and exceeding the retry limit.
+
+Check:
+- Whether a specific resource is receiving a high volume of concurrent updates
+- Whether the serialization retry count is configured appropriately for your workload


### PR DESCRIPTION
Improvements and Additions to Running Kessel section with more monitoring info:
* added a new "Monitoring Kessel Services" guide covering generic Kessel monitoring to go along with the existing replication monitoring guide
* improves the "Monitoring Data Replication" guide with some useful info from the internal guide like example alerting queries for each KPI, metrics names and sources, and a troubleshooting section
* removed Relations API references since it is merging into Inventory API
* reordered the monitoring sidebar so the general services guide appears before the replication-specific guide
