### PR TITLE
chore: onboard repository to Fleet Engineering Agentic SDLC

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,6 +49,37 @@ This repository uses `rh-multi-pre-commit` for Red Hat security scanning. The ho
 - Custom CSS is discouraged - the comment in `src/styles/global.css` states: "Use custom css only in exceptional circumstances"
 - Prefer Starlight's built-in theming and Tailwind utilities
 
+## Personal configuration
+
+Read `.claude/user.local.md` at the start of any task that needs an assignee, email, or project key.
+If the file does not exist, fall back to Claude memory (`user-config`), then placeholders.
+Run `make personalize` to generate it (if this repo uses Fleet Engineering tooling).
+
+## Fleet Engineering Skills
+
+Fetch and apply the relevant skill when the task matches its domain.
+
+| Skill | When to use |
+|---|---|
+| [bug-specialist](https://raw.githubusercontent.com/OpenShift-Fleet/agentic-sdlc/main/skills/jira/bug-specialist/SKILL.md) | Bug triage, reproduction steps, fix planning |
+| [epic-specialist](https://raw.githubusercontent.com/OpenShift-Fleet/agentic-sdlc/main/skills/jira/epic-specialist/SKILL.md) | Multi-sprint epics with outcomes |
+| [feature-specialist](https://raw.githubusercontent.com/OpenShift-Fleet/agentic-sdlc/main/skills/jira/feature-specialist/SKILL.md) | Large customer-facing capabilities |
+| [initiative-specialist](https://raw.githubusercontent.com/OpenShift-Fleet/agentic-sdlc/main/skills/jira/initiative-specialist/SKILL.md) | Multi-team strategic programs |
+| [jira-create](https://raw.githubusercontent.com/OpenShift-Fleet/agentic-sdlc/main/skills/jira/jira-create/SKILL.md) | Interactive issue creation with specialist delegation |
+| [jira-specialist](https://raw.githubusercontent.com/OpenShift-Fleet/agentic-sdlc/main/skills/jira/jira-specialist/SKILL.md) | General triage, search, linking, transitions |
+| [outcome-specialist](https://raw.githubusercontent.com/OpenShift-Fleet/agentic-sdlc/main/skills/jira/outcome-specialist/SKILL.md) | Strategic outcomes tied to OKRs |
+| [spike-specialist](https://raw.githubusercontent.com/OpenShift-Fleet/agentic-sdlc/main/skills/jira/spike-specialist/SKILL.md) | Time-boxed research and PoC |
+| [story-specialist](https://raw.githubusercontent.com/OpenShift-Fleet/agentic-sdlc/main/skills/jira/story-specialist/SKILL.md) | User stories with acceptance criteria |
+| [task-specialist](https://raw.githubusercontent.com/OpenShift-Fleet/agentic-sdlc/main/skills/jira/task-specialist/SKILL.md) | Internal technical tasks |
+| [agent-memory-setup](https://raw.githubusercontent.com/OpenShift-Fleet/agentic-sdlc/main/skills/sdlc/agent-memory-setup/SKILL.md) | Initialize or update CLAUDE.md / AGENTS.md for a repo |
+| [finish-work](https://raw.githubusercontent.com/OpenShift-Fleet/agentic-sdlc/main/skills/sdlc/finish-work/SKILL.md) | Commit, push, open PR, update Jira |
+| [pr-fix](https://raw.githubusercontent.com/OpenShift-Fleet/agentic-sdlc/main/skills/sdlc/pr-fix/SKILL.md) | Fix blocked PRs: merge conflicts, CI failures, review comments |
+| [pr-review](https://raw.githubusercontent.com/OpenShift-Fleet/agentic-sdlc/main/skills/sdlc/pr-review/SKILL.md) | GitHub PR review with worktree isolation and inline comments |
+| [repo-content-audit](https://raw.githubusercontent.com/OpenShift-Fleet/agentic-sdlc/main/skills/sdlc/repo-content-audit/SKILL.md) | Scan for unlinked or orphaned content — catalog gaps, dead links, missing cross-references |
+| [start-work](https://raw.githubusercontent.com/OpenShift-Fleet/agentic-sdlc/main/skills/sdlc/start-work/SKILL.md) | Create a Jira sub-task |
+| [f2f-daily-summary](https://raw.githubusercontent.com/OpenShift-Fleet/agentic-sdlc/main/skills/meetings/f2f-daily-summary/SKILL.md) | Capture daily F2F meeting notes as Jira sub-tasks |
+| [f2f-epic-specialist](https://raw.githubusercontent.com/OpenShift-Fleet/agentic-sdlc/main/skills/meetings/f2f-epic-specialist/SKILL.md) | Create and manage F2F meeting Epics |
+
 ## Repository-Specific Notes
 
 - **No runtime logic**: This is a documentation site, not an application. Do not introduce backend code, database logic, or application error handling


### PR DESCRIPTION
## Summary

Onboards this repository to the Fleet Engineering Agentic SDLC workflow by updating `CLAUDE.md` with:

- **Personal configuration lookup**: Agents now check `.claude/user.local.md` for assignee, email, and project key information before falling back to memory or placeholders
- **Fleet Engineering skills catalog**: Added URL-based table of 18 skills covering Jira workflows, SDLC tasks, and meeting facilitation

## Changes

- Added `## Personal configuration` section with `.claude/user.local.md` lookup instructions
- Added `## Fleet Engineering Skills` section with complete skills table from the agentic-sdlc repository

## Notes

- ARCHITECTURE.md not created (documentation site with no runtime architecture)
- Skills wired via URL table since Fleet Engineering plugin is not installed locally
- All build/lint/test commands verified against `package.json`

🤖 Generated as part of Fleet Engineering Agentic SDLC onboarding process