### PR TITLE
updates for-red-hatters section to remove deprecated links and mention inscope

### DIFF
--- a/src/content/docs/for-red-hatters.md
+++ b/src/content/docs/for-red-hatters.md
@@ -4,7 +4,4 @@ description: Information for Red Hatters about using Kessel.
 ---
 
 Kessel is an open source project also deployed internally. To learn more about leveraging Kessel
-internally please see one of these documentation mirrors based on preferred auth method:
-
-- GitHub auth (must be a member of a Red Hat managed organization): https://project-kessel.github.io/docs-internal-overlay
-- VPN auth: https://project-kessel.pages.redhat.com/docs-internal
+internally as well as Red Hat-specific examples and configurations, see our internal docs in **inScope**


### PR DESCRIPTION
* removes links to docs-internal-overlay and mirrored VPN pages to deprecate them
* references new docs location in inScope
* does not a provide a link for security purposes, since its a private corp domain that should not be exposed to public internet