### PR TITLE
adds some minor pointers to inscope for guides with useful supplementary

### DIFF
--- a/src/content/docs/building-with-kessel/how-to/configure-authentication.mdx
+++ b/src/content/docs/building-with-kessel/how-to/configure-authentication.mdx
@@ -27,6 +27,10 @@ Each authenticator can be enabled or disabled per transport (`http` and `grpc` i
 - `curl` installed (for requesting tokens)
 - A service account with client credentials from your OIDC provider (client ID and client secret)
 
+<Aside type="tip">
+    For Red Hatters: Red Hat-specific OIDC information can be found in the supplementary "Using Authentication" guide in our inScope documentation pages.
+</Aside>
+
 ## Enabling authentication locally
 
 <Steps>

--- a/src/content/docs/running-kessel/monitoring-kessel/monitoring-data-replication-inventory-api.mdx
+++ b/src/content/docs/running-kessel/monitoring-kessel/monitoring-data-replication-inventory-api.mdx
@@ -84,6 +84,10 @@ See the [librdkafka statistics documentation](https://github.com/confluentinc/li
 
 ## Example Alerting Queries
 
+<Aside type="tip">
+    For Red Hatters: Red Hat-specific Monitoring and Alerting information can be found in the supplementary "Monitoring Data Replication" guide in our inScope documentation pages.
+</Aside>
+
 The following PromQL queries correspond to the KPIs above. Adjust thresholds and time windows to match your service's expected traffic patterns. The `job` label filters to your service's specific metrics (set by your Prometheus scrape configuration or ServiceMonitor).
 
 ### Message processing failure rate


### PR DESCRIPTION
Adds some pointers to guides with significant supplementary information in the internal docs for discoverability. The rest of the internal docs are more standalone or all reference is in public docs