### PR TITLE
RHCLOUD-48472: replaces mgmt fabric with kessel, improves docs based on feedback

### DIFF
--- a/src/content/docs/building-with-kessel/concepts/consistency.mdx
+++ b/src/content/docs/building-with-kessel/concepts/consistency.mdx
@@ -1,17 +1,17 @@
 ---
 title: Consistency model
-description: Understand Kessel's eventually consistent architecture, consistency modes, and strategies for handling replication to the authorization backend.
+description: Understand Kessel's tunable consistency model, consistency modes, and strategies for choosing the right level of freshness for your use case.
 sidebar:
   order: 80
 ---
 
 import { Aside, LinkCard } from '@astrojs/starlight/components';
 
-Kessel is a distributed system with two distinct data stores: the **inventory database** holds resource data, and the **authorization graph** holds relationships between resources, users, and permissions. When you report a resource, the data is written to the inventory database first and then flows asynchronously to the authorization backend through a Change Data Capture (CDC) pipeline. This means Kessel is **eventually consistent** -- there is always a window of time between a write and that write becoming visible to permission checks.
+Kessel is a distributed system with two distinct data stores: the **inventory database** holds resource data, and the **authorization graph** holds relationships between resources, users, and permissions. When you report a resource, the data is written to the inventory database first and then replicated to the authorization backend through a Change Data Capture (CDC) pipeline.
 
-This is not a bug or a limitation to work around. It is a deliberate architectural choice. Decoupling the write path from the authorization path allows Kessel to accept resource reports at high throughput without blocking on the authorization backend. Most authorization checks tolerate small amounts of staleness, and the replication window is typically measured in hundreds of milliseconds.
+Kessel's consistency model is **tunable**. By default, replication is asynchronous and fast (typically 100-500ms). But you can choose stronger guarantees when you need them. For example, you can get causal consistency between resource writes and reads by using write visibility `IMMEDIATE`. You can also get causal consistency for relationship queries by using the `at_least_as_fresh` mode with a consistency token from a prior operation. For security-sensitive operations like updates and deletes, `CheckForUpdate` provides full consistency with the latest committed authorization state.
 
-Understanding this consistency model is essential for building integrations that behave correctly. This document explains how data flows through the system, what consistency guarantees are available, and how to choose the right strategy for your use case.
+This is not a system that forces you to accept stale reads. It is a system that lets you choose the right trade-off between latency and freshness for each operation. This page explains how data flows through the system, what consistency guarantees are available, and how to choose the right strategy for your use case.
 
 ## How data flows
 
@@ -67,9 +67,13 @@ Use this when you need causal consistency between two operations -- for example,
 
 ### `at_least_as_acknowledged`
 
+<Aside type="caution" title="Experimental">
+This mode should be considered experimental. It is functional but has not been hardened through broad production use. For security-critical decisions, prefer `CheckForUpdate` instead.
+</Aside>
+
 The Inventory API looks up the consistency token stored in the resource's `ktn` column in the inventory database. This token represents the last state that the Consumer successfully replicated to the authorization backend. The check is guaranteed to reflect at least this committed state.
 
-Use this for critical authorization decisions where you need confidence that the check reflects the resource's current state in the database, without requiring the caller to manage tokens.
+This mode only covers changes to the resource itself. It does not account for changes to other entities that affect the result, such as a user's role binding being modified. For operations where those changes matter (updates, deletes, sensitive reads), use `CheckForUpdate` instead.
 
 ### Comparing the modes
 
@@ -77,7 +81,7 @@ Use this for critical authorization decisions where you need confidence that the
 |------|-------------|---------------------|---------|----------|
 | `minimize_latency` | None | May read stale data | Lowest | Dashboards, list views, read-heavy paths |
 | `at_least_as_fresh` | Caller-provided | At least the caller's known state | Medium | Causal consistency between operations |
-| `at_least_as_acknowledged` | Database lookup (`ktn`) | At least the last committed state | Higher | Critical access decisions |
+| `at_least_as_acknowledged` | Database lookup (`ktn`) | At least the resource's last committed state | Higher | Experimental; resource-scoped freshness |
 
 <Aside type="tip">
   When in doubt, start with `minimize_latency`. Upgrade to a stronger mode only for paths where stale authorization data would cause a visible correctness problem.
@@ -110,7 +114,7 @@ To prevent requests from hanging indefinitely if the replication pipeline is slo
 IMMEDIATE mode adds the full replication latency to the request -- typically **100-500ms** on top of the base write latency. Use IMMEDIATE mode only when your application flow genuinely requires the authorization state to be updated before proceeding.
 
 <Aside type="caution">
-  Do not add artificial `sleep()` delays in your code to wait for replication. Either use IMMEDIATE mode for guaranteed write visibility, or design your UX to handle eventual consistency gracefully (e.g., show a "processing" indicator).
+  Do not add artificial `sleep()` delays in your code to wait for replication. Either use IMMEDIATE mode for guaranteed write visibility, or design your UX to handle the replication window gracefully (for example, show a "processing" indicator).
 </Aside>
 
 ## Choosing a consistency strategy
@@ -119,13 +123,13 @@ The right consistency mode depends on what your application is doing at the mome
 
 **User is browsing a dashboard or list page.** Use `minimize_latency`. A stale result for a few hundred milliseconds is invisible to the user, and the lower latency makes the page feel responsive.
 
-**User just performed a write and is viewing the result.** Use `at_least_as_acknowledged` or set write visibility to IMMEDIATE. The user expects to see the effect of their action. Showing stale data here creates confusion ("I just shared this document, why can't my collaborator see it?").
+**User just performed a write and is viewing the result.** Set write visibility to IMMEDIATE so the authorization graph reflects the change before your response returns. The user expects to see the effect of their action. Showing stale data here creates confusion ("I just shared this document, why can't my collaborator see it?").
 
 **Your service is chaining operations.** Use `at_least_as_fresh` with a token from the prior operation. This gives you causal ordering without paying for a database lookup on every check.
 
-**Your service is making a security-critical decision.** Use `at_least_as_acknowledged`. The small additional latency is worth the guarantee that the check reflects the committed state.
+**Your service is making a security-critical decision.** Use `CheckForUpdate`. Unlike `at_least_as_acknowledged` (which only reflects changes to the resource itself), `CheckForUpdate` evaluates against the latest committed authorization state. This catches changes that affect the result indirectly, such as a user's role binding being modified. The additional latency is worth the guarantee for updates, deletes, and other sensitive operations.
 
-### UX patterns for eventual consistency
+### UX patterns for asynchronous replication
 
 If you choose not to use IMMEDIATE mode, consider these patterns:
 
@@ -137,6 +141,8 @@ If you choose not to use IMMEDIATE mode, consider these patterns:
 ## Limitations
 
 There are several constraints to be aware of when working with Kessel's consistency model:
+
+- **`at_least_as_acknowledged` is experimental and resource-scoped.** This mode only reflects changes to the target resource. It does not account for unrelated changes (such as role binding updates) that affect the permission result. For operations where those changes matter, use `CheckForUpdate`.
 
 - **Bulk operations do not support `at_least_as_acknowledged`.** `CheckBulk` and `CheckSelfBulk` span multiple resources, and looking up a consistency token per resource would be prohibitively expensive. These methods support `minimize_latency` or `at_least_as_fresh` only. (`CheckForUpdateBulk` is not affected by this limitation because it always uses full consistency, as described above.)
 

--- a/src/content/docs/building-with-kessel/how-to/migrate-from-rbac-v1-to-v2.mdx
+++ b/src/content/docs/building-with-kessel/how-to/migrate-from-rbac-v1-to-v2.mdx
@@ -39,7 +39,7 @@ For the initial migration of RBACv1 applications to Kessel, the following simpli
 
 See the Pattern Summary section in [KSL-016: Migrating host and organization level permissions](https://docs.google.com/document/d/1XnINsHuYeHEi22q_1cS0gUalX-eXl3V19gGf0Wr8NsE/edit?tab=t.0#heading=h.dtb0qssiad9s) for more information about the patterns.
 
-The patterns identified for each application are tracked in [Management Fabric Integrations](https://docs.google.com/spreadsheets/d/1V3mH2pDgXOcxeyxt0fH8RnzzmDsKRDxKzDxxmuaP1mk/edit?gid=0#gid=0)
+The patterns identified for each application are tracked in [Kessel Integrations](https://docs.google.com/spreadsheets/d/1V3mH2pDgXOcxeyxt0fH8RnzzmDsKRDxKzDxxmuaP1mk/edit?gid=0#gid=0)
 
 ## Model the permissions
 

--- a/src/content/docs/building-with-kessel/how-to/report-resources.mdx
+++ b/src/content/docs/building-with-kessel/how-to/report-resources.mdx
@@ -8,7 +8,7 @@ sidebar:
 import { Aside } from "@astrojs/starlight/components";
 import { LinkCard } from "@astrojs/starlight/components";
 
-This guide provides service providers with strategies for reliably replicating data into the Management Fabric. Successful integration requires navigating the complexities of distributed systems by selecting appropriate strategies that solve for consistency, resiliency, and durability. Depending on what guarantees your system needs, you can expect to face some challenges such as the [dual-write problem](https://www.confluent.io/blog/dual-write-problem/), [write skew](https://www.cockroachlabs.com/blog/what-write-skew-looks-like/), and more. This guide will help you understand how to address these challenges and implement a replication strategy that aligns with your application's requirements.
+This guide provides service providers with strategies for reliably replicating data into Kessel. Successful integration requires navigating the complexities of distributed systems by selecting appropriate strategies that solve for consistency, resiliency, and durability. Depending on what guarantees your system needs, you can expect to face some challenges such as the [dual-write problem](https://www.confluent.io/blog/dual-write-problem/), [write skew](https://www.cockroachlabs.com/blog/what-write-skew-looks-like/), and more. This guide will help you understand how to address these challenges and implement a replication strategy that aligns with your application's requirements.
 
 # Reporting Resources
 
@@ -25,12 +25,12 @@ There are two main approaches, each with different trade-offs:
 2. **Reporting via Async Messaging (Kafka, Change Data Capture, etc.)**
 
 - Better for applications that cannot guarantee delivery or ordering through direct API calls
-- Only provides eventual consistency
+- Does not support immediate write visibility
 - May require additional infrastructure
 
 ### Choosing an approach
 
-Your reporting strategy determines what [consistency guarantees](/building-with-kessel/concepts/consistency/) are available to your application. Direct API calls support all consistency modes, including read-after-write visibility. Async approaches provide eventual consistency, meaning there is no guaranteed upper bound on how long replication to the authorization backend takes, but generally its fractions of a second. Use this flowchart to determine which strategy fits your application.
+Your reporting strategy determines what [consistency guarantees](/building-with-kessel/concepts/consistency/) are available to your application. Direct API calls support all consistency modes, including read-after-write visibility. Async approaches do not support immediate write visibility, meaning there is no guaranteed upper bound on how long replication to the authorization backend takes, but generally it is fractions of a second. Use this flowchart to determine which strategy fits your application.
 
 ```mermaid
 flowchart TD
@@ -46,7 +46,7 @@ flowchart TD
 
     START --> Q1
     Q1 -- "Yes" --> API_IMM
-    Q1 -- "No, eventual consistency is fine" --> Q2
+    Q1 -- "No" --> Q2
     Q2 -- "Yes" --> API
     Q2 -- "No" --> Q3
     Q3 -- "Yes" --> DIRECT
@@ -56,7 +56,7 @@ flowchart TD
 | | API/SDK | API/SDK + IMMEDIATE | Direct Publishing | Outbox + CDC |
 |---|---|---|---|---|
 | **Complexity** | Low | Low | Medium | Higher |
-| **Write visibility** | Eventual (default) | Immediate | Eventual | Eventual |
+| **Write visibility** | Asynchronous (default) | Immediate | Asynchronous | Asynchronous |
 | **Atomicity guarantee** | Caller's responsibility | Caller's responsibility | Caller's responsibility | Built-in (single DB transaction) |
 | **Dual-write risk** | Yes, if not handled | Yes, if not handled | Yes, if not handled | None |
 | **Ordering and delivery** | Your app must handle both | Your app must handle both | Handled by Kafka | Handled by Kafka |
@@ -78,7 +78,7 @@ Direct API calls give you immediate visibility and synchronous error handling, w
 
 ## Reporting via Async Messaging
 
-Asynchronous messaging is a good alternative when your application needs decoupled, fault-tolerant data replication. Unlike direct API calls that can fail due to network issues or service unavailability, async messaging offers built-in resilience through message persistence, retries, and eventual consistency. This approach works well for high-volume applications or those that cannot block business operations while waiting for external acknowledgments.
+Asynchronous messaging is a good alternative when your application needs decoupled, fault-tolerant data replication. Unlike direct API calls that can fail due to network issues or service unavailability, async messaging offers built-in resilience through message persistence and retries. This approach works well for high-volume applications or those that cannot block business operations while waiting for external acknowledgments.
 
 ### Direct Publishing
 
@@ -94,7 +94,7 @@ Writing to your database and publishing events to a message broker are two separ
 
 ## The Outbox Pattern
 
-The outbox pattern writes both your business data and messaging events within the same database transaction, using a dedicated outbox table. When paired with [Debezium](https://debezium.io/) for CDC, the outbox table feeds events to a message broker, keeping your database and downstream consumers eventually in sync.
+The outbox pattern writes both your business data and messaging events within the same database transaction, using a dedicated outbox table. When paired with [Debezium](https://debezium.io/) for CDC, the outbox table feeds events to a message broker, keeping your database and downstream consumers in sync.
 
 ### The Outbox Table
 

--- a/src/content/docs/building-with-kessel/reference/glossary.mdx
+++ b/src/content/docs/building-with-kessel/reference/glossary.mdx
@@ -179,7 +179,7 @@ See [Report resources](/docs/building-with-kessel/how-to/report-resources/).
 
 ### Consistency Mode
 
-The level of freshness guaranteed when performing a [Check](#check). Kessel provides several modes that let services choose whether to prioritize speed or data freshness when evaluating permissions.
+The level of freshness guaranteed when performing a [Check](#check). Kessel's consistency model is tunable: services choose the right trade-off between latency and data freshness for each operation, from fast reads with `minimize_latency` to fully consistent checks with `CheckForUpdate`.
 
 See [Consistency model](/docs/building-with-kessel/concepts/consistency/).
 

--- a/src/content/docs/running-kessel/architecture.mdx
+++ b/src/content/docs/running-kessel/architecture.mdx
@@ -9,7 +9,7 @@ import archDiagramUrl from 'src/assets/architecture.svg?url';
 
 Kessel is a distributed system that keeps track of resources reported by services, and answers permission questions about those resources. Services talk to a single API (Kessel Inventory API) for both.
 
-When a resource is written, the corresponding permission data is replicated to the authorization backend, either asynchronously (default) or synchronously if the service requests immediate consistency. Kessel offers different consistency modes so services can choose whether to prioritize speed or freshness when checking permissions. See [Consistency model](/building-with-kessel/concepts/consistency/) for details.
+When a resource is written, the corresponding permission data is replicated to the authorization backend, either asynchronously (default) or synchronously if the service requests immediate consistency. Kessel offers different consistency modes so services can choose whether to prioritize speed or freshness when checking permissions. See [Consistency model](/docs/building-with-kessel/concepts/consistency/) for details.
 
 ## Components
 
@@ -46,7 +46,7 @@ When using the default async replication, there is a brief window between a writ
 <LinkCard
   title="Consistency model"
   description="Deep dive into consistency modes, tokens, and strategies for choosing the right mode."
-  href="/building-with-kessel/concepts/consistency/"
+  href="/docs/building-with-kessel/concepts/consistency/"
 />
 
 ## Event-driven integration
@@ -72,7 +72,7 @@ Services can integrate with Kessel either by calling the Inventory API directly 
 <LinkCard
   title="Consistency model"
   description="Understand consistency modes, tokens, and how to choose the right strategy."
-  href="/building-with-kessel/concepts/consistency/"
+  href="/docs/building-with-kessel/concepts/consistency/"
 />
 
 <LinkCard

--- a/src/content/docs/start-here/getting-started.mdx
+++ b/src/content/docs/start-here/getting-started.mdx
@@ -333,9 +333,9 @@ In this example, a document is reported along with its relationship to a workspa
 Once Kessel knows about a resource and its relationships, you can check whether a user has a specific permission on it.
 
 <Aside type="caution" title="Consistency: what to expect">
-Kessel is eventually consistent. After reporting a resource, there is a brief window (typically 100-500ms) where permission checks may not yet reflect the change. If your check returns `ALLOWED_FALSE` right after a report, that's expected.
+By default, there is a brief window (typically 100-500ms) between reporting a resource and that change being visible to permission checks. If your check returns `ALLOWED_FALSE` right after a report, wait a moment and try again.
 
-Kessel provides several ways to handle this, including fully consistent checks (`CheckForUpdate`) and write visibility modes. See the [Consistency model](/docs/building-with-kessel/concepts/consistency/) for details.
+Kessel's consistency model is tunable. You can use `CheckForUpdate` for fully consistent checks, or IMMEDIATE write visibility to eliminate the replication window entirely. See the [Consistency model](/docs/building-with-kessel/concepts/consistency/) for details.
 </Aside>
 
 <CodeExamples files={gettingStartedExamples} regions="check" />


### PR DESCRIPTION
* removes any reference to Management Fabric in favor of Kessel
* updates a few docs/key points worth being explicit about based on feedback from Alec 