### PR TITLE
RHCLOUD-47190:  adds an integration with Kessel tutorial

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -45,6 +45,7 @@ const baseStarlightConfig = {
       items: [
         "start-here/getting-started",
         "start-here/understanding-kessel",
+        "start-here/add-kessel-to-app",
         "start-here/roadmap",
       ],
     },

--- a/src/content/docs/building-with-kessel/how-to/run-with-docker.mdx
+++ b/src/content/docs/building-with-kessel/how-to/run-with-docker.mdx
@@ -80,8 +80,7 @@ run the [integration test](#run-the-integration-test) or interact directly with 
 </Steps>
 
 <Aside type="note">
-The first run downloads several container images and may take a few minutes. Subsequent starts reuse cached images and are much faster.
-The Kafka infrastructure typically takes about 60 seconds to become fully ready.
+Each run ensures the latest images are pulled down to avoid issues with stale versions of each service. The Kafka infrastructure typically takes about 60 seconds to become fully ready.
 </Aside>
 
 To check that all containers are running and healthy (Docker users: substitute `docker` for `podman`):

--- a/src/content/docs/start-here/add-kessel-to-app.mdx
+++ b/src/content/docs/start-here/add-kessel-to-app.mdx
@@ -1,0 +1,387 @@
+---
+title: "Tutorial: Add Kessel to an existing application"
+description: Walk through the process of integrating Kessel into an existing service, from designing a permission schema to checking permissions.
+---
+
+import { Aside, CardGrid, LinkCard, Steps } from '@astrojs/starlight/components';
+
+**Time: ~45 minutes**
+
+This tutorial walks you through integrating Kessel into an application you already have. By the end, you will have:
+
+1. **Designed a permission schema** for a custom resource type
+2. **Compiled and loaded the schema** into a running Kessel instance
+3. **Reported a resource** to Kessel with a workspace relationship
+4. **Checked permissions** to verify access control works
+
+The tutorial uses a task management service as an example: users create tasks, organize them into workspaces (projects), and control who can view or edit them. The same process applies to any application.
+
+<Aside type="tip" title="New to Kessel?">
+If you haven't used Kessel before, start with the [Quick Start](../getting-started/) to get familiar with the basics. This tutorial assumes you have completed the Quick Start and understand resources, schema, roles, and permission checks.
+</Aside>
+
+## Prerequisites
+
+You need the following tools installed (all covered in the [Quick Start prerequisites](../getting-started/#prerequisites)):
+
+- **`ksl`** schema compiler ([install instructions](../getting-started/#prerequisites))
+- **`grpcurl`** for gRPC API calls ([install instructions](../getting-started/#prerequisites))
+- A **running Kessel instance** (see [Run locally with Docker Compose](/docs/building-with-kessel/how-to/run-with-docker/#start-the-stack))
+
+Create a working directory for this tutorial:
+
+```bash
+mkdir -p kessel-task-tutorial
+cd kessel-task-tutorial
+```
+
+## Step 1: Map your resources
+
+Before writing any code, identify what your application manages and how it maps to Kessel's model.
+
+Ask yourself:
+
+- **What are the "things" my application manages?** These are your resource types.
+- **How are they organized?** Do resources belong to a parent container? In Kessel, the built-in **workspace** resource handles this grouping.
+- **Who needs access, and what kind?** What permissions does each resource type need?
+
+For the task manager example, the mapping looks like this:
+
+| Your application | Kessel concept |
+|---|---|
+| Project | Workspace (built-in) |
+| Task | Custom resource type `task` |
+| "Can view tasks" | Permission `task_view` on workspace |
+| "Can edit tasks" | Permission `task_edit` on workspace |
+| Team member | Principal with a role binding |
+
+<Aside type="note">
+Not every application concept maps directly to a Kessel concept. The goal is to identify the resources that need access control and find the right level of granularity. See [Design permissions](/docs/building-with-kessel/how-to/design-permissions/) for guidance on common patterns.
+</Aside>
+
+## Step 2: Design and compile your permission schema
+
+With your resources mapped, write a KSL schema that describes them.
+
+<Steps>
+1. **Create the base schema files.**
+
+    Kessel requires two built-in schema files. These are the same ones used in the Quick Start.
+
+    ```bash
+    cat > kessel.ksl << 'EOF'
+    version 0.1
+    namespace kessel
+
+    internal type lock {
+        relation #version: [ExactlyOne lockversion]
+    }
+
+    internal type lockversion {}
+    EOF
+    ```
+
+    ```bash
+    cat > rbac.ksl << 'EOF'
+    version 0.1
+    namespace rbac
+
+    public type principal {}
+
+    public type group {
+        relation member: [Any principal or group.member]
+    }
+
+    public type role {
+    }
+
+    public type role_binding {
+        relation subject: [Any principal or group.member]
+        relation granted: [AtLeastOne role]
+    }
+
+    public type workspace {
+        relation parent: [AtMostOne workspace]
+        relation user_grant: [Any role_binding]
+    }
+
+    public extension add_permission(name) {
+        type role {
+            private relation `${name}`: [bool]
+        }
+
+        type role_binding {
+            internal relation `${name}`: subject and granted.`${name}`
+        }
+
+        type workspace {
+            internal relation `${name}`: user_grant.`${name}` or parent.`${name}`
+        }
+    }
+    EOF
+    ```
+
+2. **Write your resource type schema.**
+
+    Create `taskmanager.ksl` with permissions for viewing and editing tasks:
+
+    ```bash
+    cat > taskmanager.ksl << 'EOF'
+    version 0.1
+    namespace taskmanager
+
+    import rbac
+
+    @rbac.add_permission(name:'task_view')
+    @rbac.add_permission(name:'task_edit')
+
+    public type task {
+        relation workspace: [ExactlyOne rbac.workspace]
+
+        relation view: workspace.task_view
+        relation edit: workspace.task_edit
+    }
+    EOF
+    ```
+
+    This tells Kessel:
+
+    - There are two permissions (`task_view` and `task_edit`) that can be granted through roles
+    - There is a resource type called `task` that belongs to exactly one workspace
+    - The `view` and `edit` permissions on a task are inherited from its workspace
+
+3. **Compile the schema.**
+
+    ```bash
+    ksl kessel.ksl rbac.ksl taskmanager.ksl
+    ```
+
+    This produces a `schema.zed` file. If you see errors, check that all three `.ksl` files are in the current directory.
+</Steps>
+
+## Step 3: Create resource type configuration
+
+Kessel also needs configuration files that describe your resource type's attributes.
+
+<Steps>
+1. **Create the directory structure.**
+
+    ```bash
+    mkdir -p task/reporters/taskmanager
+    ```
+
+2. **Define the resource type.**
+
+    ```bash
+    cat > task/config.yaml << 'EOF'
+    resource_type: task
+    resource_reporters:
+      - TASKMANAGER
+    EOF
+    ```
+
+3. **Define the common representation schema.**
+
+    This describes the attributes shared across all reporters. The `workspace_id` field is required to place the task in a workspace for access control.
+
+    ```bash
+    cat > task/common_representation.json << 'EOF'
+    {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "properties": {
+        "workspace_id": { "type": "string" }
+      },
+      "required": [
+        "workspace_id"
+      ]
+    }
+    EOF
+    ```
+
+4. **Define the reporter configuration and schema.**
+
+    ```bash
+    cat > task/reporters/taskmanager/config.yaml << 'EOF'
+    resource_type: task
+    reporter_name: taskmanager
+    namespace: taskmanager
+    EOF
+    ```
+
+    ```bash
+    cat > task/reporters/taskmanager/task.json << 'EOF'
+    {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "properties": {
+        "title": { "type": "string" },
+        "status": { "type": "string", "enum": ["todo", "in_progress", "done"] },
+        "assignee": { "type": "string" }
+      },
+      "required": [
+        "title"
+      ]
+    }
+    EOF
+    ```
+</Steps>
+
+## Step 4: Load the schema into Kessel
+
+Load your resource type and compiled schema into a running Kessel instance.
+
+<Steps>
+1. **Copy your resource type into the Inventory API schema directory.**
+
+    Replace `/path/to/inventory-api` with the path to your local `inventory-api` clone.
+
+    ```bash
+    cp -r task/ /path/to/inventory-api/data/schema/resources/
+    ```
+
+2. **Preload the schema and restart Kessel.**
+
+    ```bash
+    cd /path/to/inventory-api
+    go run main.go preload-schema
+    SCHEMA_ZED_FILE=/path/to/kessel-task-tutorial/schema.zed make kessel-down kessel-up
+    ```
+</Steps>
+
+## Step 5: Set up roles and access
+
+Before you can check permissions, a user needs access. In Kessel, roles and role bindings are created by writing tuples to the Relations API.
+
+<Steps>
+1. **Create a role.**
+
+    A role is a set of permission tuples. This creates a "task-viewer" role with the `task_view` permission.
+
+    ```bash
+    ROLE_NAME="task-viewer"
+    PERMISSIONS=("task_view")
+    RELATIONS_PORT=9000
+
+    TUPLES=""
+    for i in "${!PERMISSIONS[@]}"; do
+        PERM="${PERMISSIONS[$i]}"
+        TUPLE="{\"resource\":{\"id\":\"${ROLE_NAME}\",\"type\":{\"name\":\"role\",\"namespace\":\"rbac\"}},\"relation\":\"${PERM}\",\"subject\":{\"subject\":{\"id\":\"*\",\"type\":{\"name\":\"principal\",\"namespace\":\"rbac\"}}}}"
+        if [ $i -gt 0 ]; then
+            TUPLES="${TUPLES},"
+        fi
+        TUPLES="${TUPLES}${TUPLE}"
+    done
+
+    grpcurl -plaintext -d "{\"tuples\":[${TUPLES}]}" \
+        "localhost:${RELATIONS_PORT}" \
+        kessel.relations.v1beta1.KesselTupleService.CreateTuples
+    ```
+
+2. **Create a role binding.**
+
+    A role binding grants a role to a subject on a specific workspace. This creates three tuples that tie together the role, the user, and the workspace.
+
+    ```bash
+    ROLE_NAME="task-viewer"
+    USER_ID="user-123"
+    RESOURCE_ID="project-alpha"
+    RELATIONS_PORT=9000
+    BINDING_ID="${ROLE_NAME}--${USER_ID}--${RESOURCE_ID}"
+
+    grpcurl -plaintext -d "{\"tuples\":[
+      {\"resource\":{\"id\":\"${BINDING_ID}\",\"type\":{\"name\":\"role_binding\",\"namespace\":\"rbac\"}},\"relation\":\"granted\",\"subject\":{\"subject\":{\"id\":\"${ROLE_NAME}\",\"type\":{\"name\":\"role\",\"namespace\":\"rbac\"}}}},
+      {\"resource\":{\"id\":\"${BINDING_ID}\",\"type\":{\"name\":\"role_binding\",\"namespace\":\"rbac\"}},\"relation\":\"subject\",\"subject\":{\"subject\":{\"id\":\"${USER_ID}\",\"type\":{\"name\":\"principal\",\"namespace\":\"rbac\"}}}},
+      {\"resource\":{\"id\":\"${RESOURCE_ID}\",\"type\":{\"name\":\"workspace\",\"namespace\":\"rbac\"}},\"relation\":\"user_grant\",\"subject\":{\"subject\":{\"id\":\"${BINDING_ID}\",\"type\":{\"name\":\"role_binding\",\"namespace\":\"rbac\"}}}}
+    ]}" \
+        "localhost:${RELATIONS_PORT}" \
+        kessel.relations.v1beta1.KesselTupleService.CreateTuples
+    ```
+</Steps>
+
+## Step 6: Report a resource
+
+Tell Kessel about a task, including its relationship to a workspace.
+
+```bash
+grpcurl -plaintext -d '{
+  "type": "task",
+  "reporterType": "TASKMANAGER",
+  "reporterInstanceId": "taskmanager-001",
+  "representations": {
+    "metadata": {
+      "localResourceId": "task-001",
+      "apiHref": "https://taskmanager.example.com/api/tasks/task-001",
+      "consoleHref": "https://taskmanager.example.com/tasks/task-001",
+      "reporterVersion": "1.0.0"
+    },
+    "common": {
+      "workspace_id": "project-alpha"
+    },
+    "reporter": {
+      "title": "Fix login bug",
+      "status": "in_progress",
+      "assignee": "user-123"
+    }
+  }
+}' localhost:9081 kessel.inventory.v1beta2.KesselInventoryService.ReportResource
+```
+
+## Step 7: Check permissions
+
+Verify that the user has access to the task through their role binding on the workspace.
+
+```bash
+grpcurl -plaintext -d '{
+  "object": {
+    "resource_type": "task",
+    "resource_id": "task-001",
+    "reporter": {
+      "type": "TASKMANAGER"
+    }
+  },
+  "relation": "view",
+  "subject": {
+    "resource": {
+      "resource_type": "principal",
+      "resource_id": "user-123",
+      "reporter": {
+        "type": "rbac"
+      }
+    }
+  }
+}' localhost:9081 kessel.inventory.v1beta2.KesselInventoryService.Check
+```
+
+If the role binding and workspace relationship are set up correctly, this should return `ALLOWED_TRUE`.
+
+<Aside type="caution" title="Eventual consistency">
+Kessel is eventually consistent. If your check returns `ALLOWED_FALSE` right after reporting the resource, wait a moment and try again. See the [Consistency model](/docs/building-with-kessel/concepts/consistency/) for details on consistency guarantees.
+</Aside>
+
+## What you learned
+
+In this tutorial, you:
+
+- **Mapped your resources** to Kessel's model by identifying resource types, relationships, and permissions
+- **Designed a permission schema** using KSL with `@rbac.add_permission` and a custom resource type
+- **Created resource type configuration** including JSON Schema for validation
+- **Loaded the schema** into a running Kessel instance
+- **Set up roles and access** by writing tuples to the Relations API
+- **Reported a resource** to Kessel's inventory with a workspace relationship
+- **Checked permissions** to verify access flows from workspace to resource
+
+The process for any application follows this same pattern: map your resources, write a schema, configure the resource type, and add reporting and permission checks.
+
+## Next steps
+
+<CardGrid>
+  <LinkCard title="Design permissions" href="/docs/building-with-kessel/how-to/design-permissions/" description="Patterns for common authorization scenarios." />
+  <LinkCard title="Add a resource type" href="/docs/building-with-kessel/how-to/add-resource-type/" description="Full reference for resource type configuration files." />
+  <LinkCard title="Report resources" href="/docs/building-with-kessel/how-to/report-resources/" description="Handle multiple reporters, representations, and deletions." />
+  <LinkCard title="Protect an endpoint" href="/docs/building-with-kessel/how-to/protect-endpoint/" description="Add permission checks with SDK code examples." />
+</CardGrid>
+
+<Aside type="tip" title="Migrating from RBAC v1?">
+If your application currently uses the legacy Insights RBAC system, see [Migrate from RBAC v1 to RBAC v2](/docs/building-with-kessel/how-to/migrate-from-rbac-v1-to-v2/) for specific guidance on converting permission definitions and adapting authorization checks.
+</Aside>

--- a/src/content/docs/start-here/add-kessel-to-app.mdx
+++ b/src/content/docs/start-here/add-kessel-to-app.mdx
@@ -70,6 +70,10 @@ This defines two permissions (`task_view`, `task_edit`) that flow through the wo
 
 For the full schema workflow (writing the base `kessel.ksl` and `rbac.ksl` files, compiling with `ksl`, creating resource type configuration, and loading into Kessel), see the Quick Start sections on [configuring resources](../getting-started/#configure-resources) and [installing Kessel](../getting-started/#install-and-run-kessel). The steps below assume your schema is compiled and loaded.
 
+<Aside type="tip" title="Need the complete files?">
+The KSL schema, resource type configuration, and full working code examples for this tutorial are available in the [examples/integrate](https://github.com/project-kessel/docs/tree/main/src/examples/integrate) directory. Use them as a reference if you get stuck.
+</Aside>
+
 ## Add the SDK and create an authenticated client
 
 The Quick Start uses `insecure()` mode for local development. For a real integration, configure the SDK with OAuth2 credentials and TLS.
@@ -83,6 +87,10 @@ The Quick Start uses `insecure()` mode for local development. For a real integra
 
     <CodeExamples files={integrationExamples} regions="client-setup" />
 
+    <Aside type="note" title="Environment variables differ by language">
+    Go passes the token endpoint directly via `KESSEL_TOKEN_ENDPOINT`. Python and TypeScript discover it automatically via OIDC discovery from `KESSEL_ISSUER_URL`. Both approaches produce the same result, but your environment setup will differ depending on which language you use. Check the code tab for the specific variables your language expects.
+    </Aside>
+
     For a detailed walkthrough of TLS certificate loading and OAuth2 configuration, see [Enable TLS](/docs/building-with-kessel/how-to/enable-tls/).
 </Steps>
 
@@ -95,6 +103,8 @@ When developing locally against a Kessel instance started with `make kessel-up`,
 Your service needs to tell Kessel about resources as they are created, updated, and deleted. The natural place to do this is right after your existing database operations.
 
 The pattern is straightforward: after your service method successfully writes to the database, report the resource to Kessel. If the Kessel report fails, log the error but don't fail the request. The resource exists in your database and Kessel will catch up on the next report.
+
+The example below shows the create path. Deletes follow the same pattern: after removing the resource from your database, call `ReportResource` with `resource_deleted: true` so Kessel removes it from the authorization graph. See the [complete examples](https://github.com/project-kessel/docs/tree/main/src/examples/integrate) for the full create and delete implementation.
 
 <CodeExamples files={integrationExamples} regions="report-on-create" />
 
@@ -113,7 +123,7 @@ For high-throughput services, reporting inline may not be practical. See [Report
 The most impactful integration point is adding permission checks to your existing endpoints. Rather than scattering `Check` calls through every service method, wrap them in a gRPC server interceptor that runs before the handler executes.
 
 The interceptor:
-1. Extracts the user identity and resource ID from gRPC metadata
+1. Extracts the user identity from gRPC metadata and the resource ID from the request or metadata (the approach varies by language)
 2. Calls Kessel's `Check` API
 3. Returns `PERMISSION_DENIED` if the user lacks the required permission
 4. Forwards the call to the handler if access is granted

--- a/src/content/docs/start-here/add-kessel-to-app.mdx
+++ b/src/content/docs/start-here/add-kessel-to-app.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Tutorial: Add Kessel to an existing application"
-description: Integrate Kessel authorization into your existing service by mapping resources, setting up authenticated clients, reporting at CRUD boundaries, and checking permissions with gRPC interceptors.
+description: Integrate Kessel authorization into your existing service by mapping resources, creating a client, reporting at CRUD boundaries, and checking permissions with gRPC interceptors.
 ---
 
 import { Aside, CardGrid, LinkCard, Steps } from '@astrojs/starlight/components';
@@ -74,29 +74,21 @@ For the full schema workflow (writing the base `kessel.ksl` and `rbac.ksl` files
 The KSL schema, resource type configuration, and full working code examples for this tutorial are available in the [examples/integrate](https://github.com/project-kessel/docs/tree/main/src/examples/integrate) directory. Use them as a reference if you get stuck.
 </Aside>
 
-## Add the SDK and create an authenticated client
-
-The Quick Start uses `insecure()` mode for local development. For a real integration, configure the SDK with OAuth2 credentials and TLS.
+## Add the SDK and create a client
 
 <Steps>
 1. **Install the SDK** in your project. See the [Quick Start prerequisites](../getting-started/#set-up-your-environment) for language-specific install commands.
 
-2. **Create an authenticated client.**
+2. **Create a client.**
 
-    The examples below use environment variables for credentials. In production, your service account credentials come from your platform's secret management (for example, Vault or app-interface secrets).
+    Set the `KESSEL_ENDPOINT` environment variable to your Kessel instance address (for example, `localhost:9081`).
 
     <CodeExamples files={integrationExamples} regions="client-setup" />
 
-    <Aside type="note" title="Environment variables differ by language">
-    Go passes the token endpoint directly via `KESSEL_TOKEN_ENDPOINT`. Python and TypeScript discover it automatically via OIDC discovery from `KESSEL_ISSUER_URL`. Both approaches produce the same result, but your environment setup will differ depending on which language you use. Check the code tab for the specific variables your language expects.
+    <Aside type="note">
+    The SDKs also support authenticated connections with OAuth2 credentials and TLS. When your environment requires authentication, each SDK provides an `authenticated()` or `oauth2_client_authenticated()` builder that accepts client credentials and channel credentials. See the SDK source for details.
     </Aside>
-
-    For a detailed walkthrough of TLS certificate loading and OAuth2 configuration, see [Enable TLS](/docs/building-with-kessel/how-to/enable-tls/).
 </Steps>
-
-<Aside type="tip" title="Local development">
-When developing locally against a Kessel instance started with `make kessel-up`, use the `insecure()` builder from the [Quick Start](../getting-started/#set-up-your-environment) instead. Switch to authenticated clients when deploying to shared environments.
-</Aside>
 
 ## Report resources at your CRUD boundaries
 
@@ -133,7 +125,7 @@ The interceptor:
 This pattern keeps authorization logic separate from business logic. Your service methods don't need to know about Kessel; they only run if the interceptor allows the call through.
 
 <Aside type="caution" title="Adapt to your framework">
-The examples above show gRPC server interceptors for Go, Python, and TypeScript. The same pattern applies to any gRPC framework: extract user and resource identifiers from metadata, call `Check`, and gate the request on the result.
+The examples above show gRPC server interceptors in each language. The same pattern applies to any gRPC framework: extract user and resource identifiers from metadata, call `Check`, and gate the request on the result.
 </Aside>
 
 ## Choose your consistency strategy
@@ -154,12 +146,16 @@ For the full set of consistency modes, tokens, and strategies, see the [Consiste
 In this tutorial, you:
 
 - **Mapped your resources** to Kessel's model, identifying resource types, workspaces, and permissions
-- **Created an authenticated client** with OAuth2 and TLS for production use
+- **Created a Kessel client** using the SDK
 - **Reported resources at your CRUD boundaries** by adding Kessel reporting alongside your existing database operations
 - **Checked permissions with a gRPC interceptor**, gating requests on Kessel authorization without changing your service methods
 - **Chose a consistency strategy** using `Check` for reads and `CheckForUpdate` for writes and security-critical decisions
 
 These are the integration seams you'll use in any Kessel-enabled service. The patterns are the same whether your application manages tasks, hosts, clusters, or any other resource type.
+
+<Aside type="tip" title="Migrating from RBAC v1?">
+If your application currently uses the legacy Insights RBAC system, see [Migrate from RBAC v1 to RBAC v2](/docs/building-with-kessel/how-to/migrate-from-rbac-v1-to-v2/) for specific guidance on converting permission definitions and adapting authorization checks.
+</Aside>
 
 ## Next steps
 
@@ -169,7 +165,3 @@ These are the integration seams you'll use in any Kessel-enabled service. The pa
   <LinkCard title="Design permissions" href="/docs/building-with-kessel/how-to/design-permissions/" description="Authorization patterns for hierarchical resources, shared access, and org-wide settings." />
   <LinkCard title="Consistency model" href="/docs/building-with-kessel/concepts/consistency/" description="Tunable consistency modes, write visibility, and strategies for handling replication." />
 </CardGrid>
-
-<Aside type="tip" title="Migrating from RBAC v1?">
-If your application currently uses the legacy Insights RBAC system, see [Migrate from RBAC v1 to RBAC v2](/docs/building-with-kessel/how-to/migrate-from-rbac-v1-to-v2/) for specific guidance on converting permission definitions and adapting authorization checks.
-</Aside>

--- a/src/content/docs/start-here/add-kessel-to-app.mdx
+++ b/src/content/docs/start-here/add-kessel-to-app.mdx
@@ -104,7 +104,7 @@ Your service needs to tell Kessel about resources as they are created, updated, 
 
 The pattern is straightforward: after your service method successfully writes to the database, report the resource to Kessel. If the Kessel report fails, log the error but don't fail the request. The resource exists in your database and Kessel will catch up on the next report.
 
-The example below shows the create path. Deletes follow the same pattern: after removing the resource from your database, call `ReportResource` with `resource_deleted: true` so Kessel removes it from the authorization graph. See the [complete examples](https://github.com/project-kessel/docs/tree/main/src/examples/integrate) for the full create and delete implementation.
+The example below shows the create path. Deletes follow a similar pattern: after removing the resource from your database, call `DeleteResource` with a resource reference so Kessel removes it from the authorization graph. See the [complete examples](https://github.com/project-kessel/docs/tree/main/src/examples/integrate) for the full create and delete implementation.
 
 <CodeExamples files={integrationExamples} regions="report-on-create" />
 

--- a/src/content/docs/start-here/add-kessel-to-app.mdx
+++ b/src/content/docs/start-here/add-kessel-to-app.mdx
@@ -1,41 +1,27 @@
 ---
 title: "Tutorial: Add Kessel to an existing application"
-description: Walk through the process of integrating Kessel into an existing service, from designing a permission schema to checking permissions.
+description: Integrate Kessel authorization into your existing service by mapping resources, setting up authenticated clients, reporting at CRUD boundaries, and checking permissions with gRPC interceptors.
 ---
 
 import { Aside, CardGrid, LinkCard, Steps } from '@astrojs/starlight/components';
+import CodeExamples from 'src/components/CodeExamples.astro';
+
+export const integrationExamples = import.meta.glob('/src/examples/integrate/example.*', { query: '?raw', eager: true, import: 'default' });
 
 **Time: ~45 minutes**
 
-This tutorial walks you through integrating Kessel into an application you already have. By the end, you will have:
+This tutorial walks you through integrating Kessel into a service you already have. By the end, your application will:
 
-1. **Designed a permission schema** for a custom resource type
-2. **Compiled and loaded the schema** into a running Kessel instance
-3. **Reported a resource** to Kessel with a workspace relationship
-4. **Checked permissions** to verify access control works
+1. **Report resources** to Kessel whenever it creates or deletes them
+2. **Check permissions** through a gRPC interceptor before serving requests
 
-The tutorial uses a task management service as an example: users create tasks, organize them into workspaces (projects), and control who can view or edit them. The same process applies to any application.
+Unlike the [Quick Start](../getting-started/), which builds everything from scratch, this tutorial focuses on the **integration points**; the places where Kessel code lives alongside your existing application code.
 
-<Aside type="tip" title="New to Kessel?">
-If you haven't used Kessel before, start with the [Quick Start](../getting-started/) to get familiar with the basics. This tutorial assumes you have completed the Quick Start and understand resources, schema, roles, and permission checks.
+<Aside type="tip" title="Complete the Quick Start first">
+This tutorial assumes you have completed the [Quick Start](../getting-started/) and have a running Kessel instance with a schema loaded. You should understand resources, schema, roles, and permission checks before continuing.
 </Aside>
 
-## Prerequisites
-
-You need the following tools installed (all covered in the [Quick Start prerequisites](../getting-started/#prerequisites)):
-
-- **`ksl`** schema compiler ([install instructions](../getting-started/#prerequisites))
-- **`grpcurl`** for gRPC API calls ([install instructions](../getting-started/#prerequisites))
-- A **running Kessel instance** (see [Run locally with Docker Compose](/docs/building-with-kessel/how-to/run-with-docker/#start-the-stack))
-
-Create a working directory for this tutorial:
-
-```bash
-mkdir -p kessel-task-tutorial
-cd kessel-task-tutorial
-```
-
-## Step 1: Map your resources
+## Map your resources
 
 Before writing any code, identify what your application manages and how it maps to Kessel's model.
 
@@ -45,7 +31,7 @@ Ask yourself:
 - **How are they organized?** Do resources belong to a parent container? In Kessel, the built-in **workspace** resource handles this grouping.
 - **Who needs access, and what kind?** What permissions does each resource type need?
 
-For the task manager example, the mapping looks like this:
+For a task management service, the mapping looks like this:
 
 | Your application | Kessel concept |
 |---|---|
@@ -59,327 +45,119 @@ For the task manager example, the mapping looks like this:
 Not every application concept maps directly to a Kessel concept. The goal is to identify the resources that need access control and find the right level of granularity. See [Design permissions](/docs/building-with-kessel/how-to/design-permissions/) for guidance on common patterns.
 </Aside>
 
-## Step 2: Design and compile your permission schema
+## Design your schema
 
-With your resources mapped, write a KSL schema that describes them.
+Write a KSL schema for your resource type. If you followed the Quick Start, this process is familiar. Here is what a task management schema looks like:
 
-<Steps>
-1. **Create the base schema files.**
+```ksl
+version 0.1
+namespace taskmanager
 
-    Kessel requires two built-in schema files. These are the same ones used in the Quick Start.
+import rbac
 
-    ```bash
-    cat > kessel.ksl << 'EOF'
-    version 0.1
-    namespace kessel
+@rbac.add_permission(name:'task_view')
+@rbac.add_permission(name:'task_edit')
 
-    internal type lock {
-        relation #version: [ExactlyOne lockversion]
-    }
+public type task {
+    relation workspace: [ExactlyOne rbac.workspace]
 
-    internal type lockversion {}
-    EOF
-    ```
-
-    ```bash
-    cat > rbac.ksl << 'EOF'
-    version 0.1
-    namespace rbac
-
-    public type principal {}
-
-    public type group {
-        relation member: [Any principal or group.member]
-    }
-
-    public type role {
-    }
-
-    public type role_binding {
-        relation subject: [Any principal or group.member]
-        relation granted: [AtLeastOne role]
-    }
-
-    public type workspace {
-        relation parent: [AtMostOne workspace]
-        relation user_grant: [Any role_binding]
-    }
-
-    public extension add_permission(name) {
-        type role {
-            private relation `${name}`: [bool]
-        }
-
-        type role_binding {
-            internal relation `${name}`: subject and granted.`${name}`
-        }
-
-        type workspace {
-            internal relation `${name}`: user_grant.`${name}` or parent.`${name}`
-        }
-    }
-    EOF
-    ```
-
-2. **Write your resource type schema.**
-
-    Create `taskmanager.ksl` with permissions for viewing and editing tasks:
-
-    ```bash
-    cat > taskmanager.ksl << 'EOF'
-    version 0.1
-    namespace taskmanager
-
-    import rbac
-
-    @rbac.add_permission(name:'task_view')
-    @rbac.add_permission(name:'task_edit')
-
-    public type task {
-        relation workspace: [ExactlyOne rbac.workspace]
-
-        relation view: workspace.task_view
-        relation edit: workspace.task_edit
-    }
-    EOF
-    ```
-
-    This tells Kessel:
-
-    - There are two permissions (`task_view` and `task_edit`) that can be granted through roles
-    - There is a resource type called `task` that belongs to exactly one workspace
-    - The `view` and `edit` permissions on a task are inherited from its workspace
-
-3. **Compile the schema.**
-
-    ```bash
-    ksl kessel.ksl rbac.ksl taskmanager.ksl
-    ```
-
-    This produces a `schema.zed` file. If you see errors, check that all three `.ksl` files are in the current directory.
-</Steps>
-
-## Step 3: Create resource type configuration
-
-Kessel also needs configuration files that describe your resource type's attributes.
-
-<Steps>
-1. **Create the directory structure.**
-
-    ```bash
-    mkdir -p task/reporters/taskmanager
-    ```
-
-2. **Define the resource type.**
-
-    ```bash
-    cat > task/config.yaml << 'EOF'
-    resource_type: task
-    resource_reporters:
-      - TASKMANAGER
-    EOF
-    ```
-
-3. **Define the common representation schema.**
-
-    This describes the attributes shared across all reporters. The `workspace_id` field is required to place the task in a workspace for access control.
-
-    ```bash
-    cat > task/common_representation.json << 'EOF'
-    {
-      "$schema": "http://json-schema.org/draft-07/schema#",
-      "type": "object",
-      "properties": {
-        "workspace_id": { "type": "string" }
-      },
-      "required": [
-        "workspace_id"
-      ]
-    }
-    EOF
-    ```
-
-4. **Define the reporter configuration and schema.**
-
-    ```bash
-    cat > task/reporters/taskmanager/config.yaml << 'EOF'
-    resource_type: task
-    reporter_name: taskmanager
-    namespace: taskmanager
-    EOF
-    ```
-
-    ```bash
-    cat > task/reporters/taskmanager/task.json << 'EOF'
-    {
-      "$schema": "http://json-schema.org/draft-07/schema#",
-      "type": "object",
-      "properties": {
-        "title": { "type": "string" },
-        "status": { "type": "string", "enum": ["todo", "in_progress", "done"] },
-        "assignee": { "type": "string" }
-      },
-      "required": [
-        "title"
-      ]
-    }
-    EOF
-    ```
-</Steps>
-
-## Step 4: Load the schema into Kessel
-
-Load your resource type and compiled schema into a running Kessel instance.
-
-<Steps>
-1. **Copy your resource type into the Inventory API schema directory.**
-
-    Replace `/path/to/inventory-api` with the path to your local `inventory-api` clone.
-
-    ```bash
-    cp -r task/ /path/to/inventory-api/data/schema/resources/
-    ```
-
-2. **Preload the schema and restart Kessel.**
-
-    ```bash
-    cd /path/to/inventory-api
-    go run main.go preload-schema
-    SCHEMA_ZED_FILE=/path/to/kessel-task-tutorial/schema.zed make kessel-down kessel-up
-    ```
-</Steps>
-
-## Step 5: Set up roles and access
-
-Before you can check permissions, a user needs access. In Kessel, roles and role bindings are created by writing tuples to the Relations API.
-
-<Steps>
-1. **Create a role.**
-
-    A role is a set of permission tuples. This creates a "task-viewer" role with the `task_view` permission.
-
-    ```bash
-    ROLE_NAME="task-viewer"
-    PERMISSIONS=("task_view")
-    RELATIONS_PORT=9000
-
-    TUPLES=""
-    for i in "${!PERMISSIONS[@]}"; do
-        PERM="${PERMISSIONS[$i]}"
-        TUPLE="{\"resource\":{\"id\":\"${ROLE_NAME}\",\"type\":{\"name\":\"role\",\"namespace\":\"rbac\"}},\"relation\":\"${PERM}\",\"subject\":{\"subject\":{\"id\":\"*\",\"type\":{\"name\":\"principal\",\"namespace\":\"rbac\"}}}}"
-        if [ $i -gt 0 ]; then
-            TUPLES="${TUPLES},"
-        fi
-        TUPLES="${TUPLES}${TUPLE}"
-    done
-
-    grpcurl -plaintext -d "{\"tuples\":[${TUPLES}]}" \
-        "localhost:${RELATIONS_PORT}" \
-        kessel.relations.v1beta1.KesselTupleService.CreateTuples
-    ```
-
-2. **Create a role binding.**
-
-    A role binding grants a role to a subject on a specific workspace. This creates three tuples that tie together the role, the user, and the workspace.
-
-    ```bash
-    ROLE_NAME="task-viewer"
-    USER_ID="user-123"
-    RESOURCE_ID="project-alpha"
-    RELATIONS_PORT=9000
-    BINDING_ID="${ROLE_NAME}--${USER_ID}--${RESOURCE_ID}"
-
-    grpcurl -plaintext -d "{\"tuples\":[
-      {\"resource\":{\"id\":\"${BINDING_ID}\",\"type\":{\"name\":\"role_binding\",\"namespace\":\"rbac\"}},\"relation\":\"granted\",\"subject\":{\"subject\":{\"id\":\"${ROLE_NAME}\",\"type\":{\"name\":\"role\",\"namespace\":\"rbac\"}}}},
-      {\"resource\":{\"id\":\"${BINDING_ID}\",\"type\":{\"name\":\"role_binding\",\"namespace\":\"rbac\"}},\"relation\":\"subject\",\"subject\":{\"subject\":{\"id\":\"${USER_ID}\",\"type\":{\"name\":\"principal\",\"namespace\":\"rbac\"}}}},
-      {\"resource\":{\"id\":\"${RESOURCE_ID}\",\"type\":{\"name\":\"workspace\",\"namespace\":\"rbac\"}},\"relation\":\"user_grant\",\"subject\":{\"subject\":{\"id\":\"${BINDING_ID}\",\"type\":{\"name\":\"role_binding\",\"namespace\":\"rbac\"}}}}
-    ]}" \
-        "localhost:${RELATIONS_PORT}" \
-        kessel.relations.v1beta1.KesselTupleService.CreateTuples
-    ```
-</Steps>
-
-## Step 6: Report a resource
-
-Tell Kessel about a task, including its relationship to a workspace.
-
-```bash
-grpcurl -plaintext -d '{
-  "type": "task",
-  "reporterType": "TASKMANAGER",
-  "reporterInstanceId": "taskmanager-001",
-  "representations": {
-    "metadata": {
-      "localResourceId": "task-001",
-      "apiHref": "https://taskmanager.example.com/api/tasks/task-001",
-      "consoleHref": "https://taskmanager.example.com/tasks/task-001",
-      "reporterVersion": "1.0.0"
-    },
-    "common": {
-      "workspace_id": "project-alpha"
-    },
-    "reporter": {
-      "title": "Fix login bug",
-      "status": "in_progress",
-      "assignee": "user-123"
-    }
-  }
-}' localhost:9081 kessel.inventory.v1beta2.KesselInventoryService.ReportResource
+    relation view: workspace.task_view
+    relation edit: workspace.task_edit
+}
 ```
 
-## Step 7: Check permissions
+This defines two permissions (`task_view`, `task_edit`) that flow through the workspace hierarchy, and a `task` resource type that belongs to exactly one workspace.
 
-Verify that the user has access to the task through their role binding on the workspace.
+For the full schema workflow (writing the base `kessel.ksl` and `rbac.ksl` files, compiling with `ksl`, creating resource type configuration, and loading into Kessel), see the Quick Start sections on [configuring resources](../getting-started/#configure-resources) and [installing Kessel](../getting-started/#install-and-run-kessel). The steps below assume your schema is compiled and loaded.
 
-```bash
-grpcurl -plaintext -d '{
-  "object": {
-    "resource_type": "task",
-    "resource_id": "task-001",
-    "reporter": {
-      "type": "TASKMANAGER"
-    }
-  },
-  "relation": "view",
-  "subject": {
-    "resource": {
-      "resource_type": "principal",
-      "resource_id": "user-123",
-      "reporter": {
-        "type": "rbac"
-      }
-    }
-  }
-}' localhost:9081 kessel.inventory.v1beta2.KesselInventoryService.Check
-```
+## Add the SDK and create an authenticated client
 
-If the role binding and workspace relationship are set up correctly, this should return `ALLOWED_TRUE`.
+The Quick Start uses `insecure()` mode for local development. For a real integration, configure the SDK with OAuth2 credentials and TLS.
 
-<Aside type="caution" title="Eventual consistency">
-Kessel is eventually consistent. If your check returns `ALLOWED_FALSE` right after reporting the resource, wait a moment and try again. See the [Consistency model](/docs/building-with-kessel/concepts/consistency/) for details on consistency guarantees.
+<Steps>
+1. **Install the SDK** in your project. See the [Quick Start prerequisites](../getting-started/#set-up-your-environment) for language-specific install commands.
+
+2. **Create an authenticated client.**
+
+    The examples below use environment variables for credentials. In production, your service account credentials come from your platform's secret management (for example, Vault or app-interface secrets).
+
+    <CodeExamples files={integrationExamples} regions="client-setup" />
+
+    For a detailed walkthrough of TLS certificate loading and OAuth2 configuration, see [Enable TLS](/docs/building-with-kessel/how-to/enable-tls/).
+</Steps>
+
+<Aside type="tip" title="Local development">
+When developing locally against a Kessel instance started with `make kessel-up`, use the `insecure()` builder from the [Quick Start](../getting-started/#set-up-your-environment) instead. Switch to authenticated clients when deploying to shared environments.
 </Aside>
+
+## Report resources at your CRUD boundaries
+
+Your service needs to tell Kessel about resources as they are created, updated, and deleted. The natural place to do this is right after your existing database operations.
+
+The pattern is straightforward: after your service method successfully writes to the database, report the resource to Kessel. If the Kessel report fails, log the error but don't fail the request. The resource exists in your database and Kessel will catch up on the next report.
+
+<CodeExamples files={integrationExamples} regions="report-on-create" />
+
+Key points:
+
+- **Report after the database write**, not before. The resource must exist in your system before Kessel knows about it.
+- **Include the `workspace_id`** in the common representation. This is what connects the resource to the workspace hierarchy and enables permission inheritance.
+- **Handle errors gracefully.** A Kessel outage should not prevent your service from creating resources. Log the failure and consider a reconciliation process to catch up.
+
+<Aside type="note">
+For high-throughput services, reporting inline may not be practical. See [Report resources](/docs/building-with-kessel/how-to/report-resources/) for async alternatives using the outbox pattern or Kafka consumers.
+</Aside>
+
+## Check permissions before serving requests
+
+The most impactful integration point is adding permission checks to your existing endpoints. Rather than scattering `Check` calls through every service method, wrap them in a gRPC server interceptor that runs before the handler executes.
+
+The interceptor:
+1. Extracts the user identity and resource ID from gRPC metadata
+2. Calls Kessel's `Check` API
+3. Returns `PERMISSION_DENIED` if the user lacks the required permission
+4. Forwards the call to the handler if access is granted
+
+<CodeExamples files={integrationExamples} regions="check-middleware" />
+
+This pattern keeps authorization logic separate from business logic. Your service methods don't need to know about Kessel; they only run if the interceptor allows the call through.
+
+<Aside type="caution" title="Adapt to your framework">
+The examples above show gRPC server interceptors for Go, Python, and TypeScript. The same pattern applies to any gRPC framework: extract user and resource identifiers from metadata, call `Check`, and gate the request on the result.
+</Aside>
+
+## Choose your consistency strategy
+
+Kessel's consistency model is tunable. By default, permission checks use `minimize_latency`, which may read slightly stale data. But you can achieve causal consistency ("read your writes") when your use case requires it.
+
+The two most important check methods are:
+
+- **`Check`** (default `minimize_latency`): fast, suitable for read-heavy paths like dashboards and list views. The authorization graph may lag the inventory database by 100-500ms under normal conditions, but this is invisible for most read operations.
+- **`CheckForUpdate`**: always fully consistent. The authorization backend evaluates against the latest committed state, including any recent changes to role bindings or resource relationships. Use this for updates, deletes, and any security-critical decision where acting on stale data could cause a conflict or incorrect access grant.
+
+For writes, you can also use `write_visibility: IMMEDIATE` on `ReportResource` to wait for replication to complete before returning. This guarantees that a `Check` issued immediately after the report will reflect the change, giving you causal consistency between resource writes and reads.
+
+For the full set of consistency modes, tokens, and strategies, see the [Consistency model](/docs/building-with-kessel/concepts/consistency/).
 
 ## What you learned
 
 In this tutorial, you:
 
-- **Mapped your resources** to Kessel's model by identifying resource types, relationships, and permissions
-- **Designed a permission schema** using KSL with `@rbac.add_permission` and a custom resource type
-- **Created resource type configuration** including JSON Schema for validation
-- **Loaded the schema** into a running Kessel instance
-- **Set up roles and access** by writing tuples to the Relations API
-- **Reported a resource** to Kessel's inventory with a workspace relationship
-- **Checked permissions** to verify access flows from workspace to resource
+- **Mapped your resources** to Kessel's model, identifying resource types, workspaces, and permissions
+- **Created an authenticated client** with OAuth2 and TLS for production use
+- **Reported resources at your CRUD boundaries** by adding Kessel reporting alongside your existing database operations
+- **Checked permissions with a gRPC interceptor**, gating requests on Kessel authorization without changing your service methods
+- **Chose a consistency strategy** using `Check` for reads and `CheckForUpdate` for writes and security-critical decisions
 
-The process for any application follows this same pattern: map your resources, write a schema, configure the resource type, and add reporting and permission checks.
+These are the integration seams you'll use in any Kessel-enabled service. The patterns are the same whether your application manages tasks, hosts, clusters, or any other resource type.
 
 ## Next steps
 
 <CardGrid>
-  <LinkCard title="Design permissions" href="/docs/building-with-kessel/how-to/design-permissions/" description="Patterns for common authorization scenarios." />
-  <LinkCard title="Add a resource type" href="/docs/building-with-kessel/how-to/add-resource-type/" description="Full reference for resource type configuration files." />
-  <LinkCard title="Report resources" href="/docs/building-with-kessel/how-to/report-resources/" description="Handle multiple reporters, representations, and deletions." />
-  <LinkCard title="Protect an endpoint" href="/docs/building-with-kessel/how-to/protect-endpoint/" description="Add permission checks with SDK code examples." />
+  <LinkCard title="Report resources" href="/docs/building-with-kessel/how-to/report-resources/" description="Async reporting, outbox pattern, and Kafka consumers for high-throughput services." />
+  <LinkCard title="Protect an endpoint" href="/docs/building-with-kessel/how-to/protect-endpoint/" description="Expanded patterns for endpoint protection including Check vs CheckForUpdate." />
+  <LinkCard title="Design permissions" href="/docs/building-with-kessel/how-to/design-permissions/" description="Authorization patterns for hierarchical resources, shared access, and org-wide settings." />
+  <LinkCard title="Consistency model" href="/docs/building-with-kessel/concepts/consistency/" description="Tunable consistency modes, write visibility, and strategies for handling replication." />
 </CardGrid>
 
 <Aside type="tip" title="Migrating from RBAC v1?">

--- a/src/content/docs/start-here/getting-started.mdx
+++ b/src/content/docs/start-here/getting-started.mdx
@@ -21,6 +21,8 @@ import createRoleBindingScript from 'src/examples/scripts/create-role-binding.sh
 
 export const createFile = (path, content) => `cat > ${path} << 'EOF'\n${content.trim()}\nEOF`;
 
+**Time: ~30 minutes**
+
 This tutorial walks you through setting up Kessel from scratch. By the end, you will have:
 
 1. **Run Kessel** locally with Docker Compose
@@ -343,6 +345,19 @@ Kessel provides several ways to handle this, including fully consistent checks (
 ## Complete example
 
 <CodeExamples files={gettingStartedExamples} />
+
+## What you learned
+
+In this tutorial, you:
+
+- **Defined a resource type** using KSL schema files and JSON Schema for resource attributes
+- **Compiled the schema** to SpiceDB format using the `ksl` compiler
+- **Ran the full Kessel stack** locally with Docker Compose
+- **Set up RBAC** by creating a role with permissions and binding it to a user on a workspace
+- **Reported a resource** to Kessel's inventory, including its relationship to a workspace
+- **Checked permissions** to verify that access control works through the relationship graph
+
+These are the same building blocks you'll use when integrating Kessel into a real application. The [how-to guides](/docs/building-with-kessel/how-to/report-resources/) go deeper into each step.
 
 ## Try it yourself
 

--- a/src/examples/integrate/example.go
+++ b/src/examples/integrate/example.go
@@ -1,0 +1,167 @@
+package main
+
+import (
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+	"log"
+	"os"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/types/known/structpb"
+
+	"github.com/project-kessel/kessel-sdk-go/kessel/auth"
+	kesselgrpc "github.com/project-kessel/kessel-sdk-go/kessel/grpc"
+	"github.com/project-kessel/kessel-sdk-go/kessel/inventory/v1beta2"
+)
+
+//#region client-setup
+func newKesselClient() (v1beta2.KesselInventoryServiceClient, func(), error) {
+	oauthCreds := auth.NewOAuth2ClientCredentials(
+		os.Getenv("KESSEL_CLIENT_ID"),
+		os.Getenv("KESSEL_CLIENT_SECRET"),
+		os.Getenv("KESSEL_TOKEN_ENDPOINT"),
+	)
+
+	caCert, err := os.ReadFile(os.Getenv("KESSEL_CA_CERT_PATH"))
+	if err != nil {
+		return nil, nil, fmt.Errorf("read CA cert: %w", err)
+	}
+	certPool := x509.NewCertPool()
+	certPool.AppendCertsFromPEM(caCert)
+	tlsCreds := credentials.NewTLS(&tls.Config{RootCAs: certPool})
+
+	client, conn, err := v1beta2.NewClientBuilder(os.Getenv("KESSEL_ENDPOINT")).
+		Authenticated(kesselgrpc.OAuth2CallCredentials(&oauthCreds), tlsCreds).
+		Build()
+	if err != nil {
+		return nil, nil, fmt.Errorf("build client: %w", err)
+	}
+	return client, func() { conn.Close() }, nil
+}
+
+//#endregion
+
+//#region report-on-create
+func (s *TaskService) CreateTask(ctx context.Context, req *CreateTaskRequest) (*CreateTaskResponse, error) {
+	// --- Your existing service logic ---
+	task, err := s.db.InsertTask(ctx, req)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "insert task: %v", err)
+	}
+
+	// --- Report to Kessel ---
+	_, err = s.kessel.ReportResource(ctx, &v1beta2.ReportResourceRequest{
+		Type:               "task",
+		ReporterType:       "TASKMANAGER",
+		ReporterInstanceId: s.instanceID,
+		Representations: &v1beta2.ResourceRepresentations{
+			Metadata: &v1beta2.RepresentationMetadata{
+				LocalResourceId: task.ID,
+				ApiHref:         fmt.Sprintf("%s/api/tasks/%s", s.baseURL, task.ID),
+			},
+			Common: &structpb.Struct{
+				Fields: map[string]*structpb.Value{
+					"workspace_id": structpb.NewStringValue(task.WorkspaceID),
+				},
+			},
+			Reporter: &structpb.Struct{
+				Fields: map[string]*structpb.Value{
+					"title":  structpb.NewStringValue(task.Title),
+					"status": structpb.NewStringValue(task.Status),
+				},
+			},
+		},
+	})
+	if err != nil {
+		// Log the error but don't fail the request.
+		// The resource exists in your database; Kessel will catch up
+		// on the next report or through a reconciliation process.
+		log.Printf("kessel: failed to report task %s: %v", task.ID, err)
+	}
+
+	return &CreateTaskResponse{Task: task}, nil
+}
+
+//#endregion
+
+//#region check-middleware
+func KesselAuthInterceptor(client v1beta2.KesselInventoryServiceClient, resourceType, reporterType, relation string) grpc.UnaryServerInterceptor {
+	return func(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {
+		md, ok := metadata.FromIncomingContext(ctx)
+		if !ok {
+			return nil, status.Error(codes.PermissionDenied, "missing metadata")
+		}
+
+		userIDs := md.Get("x-user-id")
+		if len(userIDs) == 0 {
+			return nil, status.Error(codes.PermissionDenied, "missing user identity")
+		}
+		userID := userIDs[0]
+
+		resourceID := extractResourceID(req)
+
+		resp, err := client.Check(ctx, &v1beta2.CheckRequest{
+			Object: &v1beta2.ResourceReference{
+				ResourceType: resourceType,
+				ResourceId:   resourceID,
+				Reporter:     &v1beta2.ReporterReference{Type: reporterType},
+			},
+			Relation: relation,
+			Subject: &v1beta2.SubjectReference{
+				Resource: &v1beta2.ResourceReference{
+					ResourceType: "principal",
+					ResourceId:   userID,
+					Reporter:     &v1beta2.ReporterReference{Type: "rbac"},
+				},
+			},
+		})
+
+		if err != nil {
+			if st, ok := status.FromError(err); ok && st.Code() == codes.Unavailable {
+				return nil, status.Error(codes.Unavailable, "authorization service unavailable")
+			}
+			return nil, status.Error(codes.PermissionDenied, "forbidden")
+		}
+
+		if resp.Allowed != v1beta2.Allowed_ALLOWED_TRUE {
+			return nil, status.Error(codes.PermissionDenied, "forbidden")
+		}
+
+		return handler(ctx, req)
+	}
+}
+
+// Wire it up when creating the gRPC server:
+//
+//   viewAuth := KesselAuthInterceptor(kesselClient, "task", "TASKMANAGER", "view")
+//   editAuth := KesselAuthInterceptor(kesselClient, "task", "TASKMANAGER", "edit")
+//
+//   server := grpc.NewServer(
+//       grpc.ChainUnaryInterceptor(viewAuth),
+//   )
+//#endregion
+
+// Type stubs for compilation context.
+type TaskService struct {
+	db         interface{ InsertTask(context.Context, *CreateTaskRequest) (Task, error) }
+	kessel     v1beta2.KesselInventoryServiceClient
+	instanceID string
+	baseURL    string
+}
+type CreateTaskRequest struct{}
+type CreateTaskResponse struct{ Task Task }
+type Task struct {
+	ID          string
+	WorkspaceID string
+	Title       string
+	Status      string
+}
+
+func extractResourceID(req interface{}) string { return "" }
+func main()                                    {}

--- a/src/examples/integrate/example.go
+++ b/src/examples/integrate/example.go
@@ -2,42 +2,23 @@ package main
 
 import (
 	"context"
-	"crypto/tls"
-	"crypto/x509"
 	"fmt"
 	"log"
 	"os"
 
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/structpb"
 
-	"github.com/project-kessel/kessel-sdk-go/kessel/auth"
-	kesselgrpc "github.com/project-kessel/kessel-sdk-go/kessel/grpc"
 	"github.com/project-kessel/kessel-sdk-go/kessel/inventory/v1beta2"
 )
 
 //#region client-setup
 func newKesselClient() (v1beta2.KesselInventoryServiceClient, func(), error) {
-	oauthCreds := auth.NewOAuth2ClientCredentials(
-		os.Getenv("KESSEL_CLIENT_ID"),
-		os.Getenv("KESSEL_CLIENT_SECRET"),
-		os.Getenv("KESSEL_TOKEN_ENDPOINT"),
-	)
-
-	caCert, err := os.ReadFile(os.Getenv("KESSEL_CA_CERT_PATH"))
-	if err != nil {
-		return nil, nil, fmt.Errorf("read CA cert: %w", err)
-	}
-	certPool := x509.NewCertPool()
-	certPool.AppendCertsFromPEM(caCert)
-	tlsCreds := credentials.NewTLS(&tls.Config{RootCAs: certPool})
-
 	client, conn, err := v1beta2.NewClientBuilder(os.Getenv("KESSEL_ENDPOINT")).
-		Authenticated(kesselgrpc.OAuth2CallCredentials(&oauthCreds), tlsCreds).
+		Insecure().
 		Build()
 	if err != nil {
 		return nil, nil, fmt.Errorf("build client: %w", err)

--- a/src/examples/integrate/example.java
+++ b/src/examples/integrate/example.java
@@ -1,0 +1,164 @@
+package com.example.taskmanager;
+
+import com.google.protobuf.Struct;
+import com.google.protobuf.Value;
+import com.nimbusds.jose.util.Pair;
+import io.grpc.*;
+import org.project_kessel.api.inventory.v1beta2.*;
+
+import java.util.Map;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import static org.project_kessel.api.inventory.v1beta2.KesselInventoryServiceGrpc.KesselInventoryServiceBlockingStub;
+
+//#region client-setup
+public class KesselClientFactory {
+    public static Pair<KesselInventoryServiceBlockingStub, ManagedChannel> createKesselClient() {
+        return new ClientBuilder(System.getenv("KESSEL_ENDPOINT"))
+                .insecure()
+                .build();
+    }
+}
+//#endregion
+
+//#region report-on-create
+public class TaskService {
+    private static final Logger logger = Logger.getLogger(TaskService.class.getName());
+    private final KesselInventoryServiceBlockingStub kesselClient;
+    private final TaskRepository db;
+    private final String instanceId;
+    private final String baseUrl;
+
+    public TaskService(KesselInventoryServiceBlockingStub kesselClient, TaskRepository db) {
+        this.kesselClient = kesselClient;
+        this.db = db;
+        this.instanceId = System.getenv().getOrDefault("REPORTER_INSTANCE_ID", "taskmanager-1");
+        this.baseUrl = System.getenv().getOrDefault("BASE_URL", "http://localhost:8080");
+    }
+
+    public Task createTask(Task task) {
+        // --- Your existing service logic ---
+        Task saved = db.insertTask(task);
+
+        // --- Report to Kessel ---
+        ReportResourceRequest request = ReportResourceRequest.newBuilder()
+                .setType("task")
+                .setReporterType("TASKMANAGER")
+                .setReporterInstanceId(instanceId)
+                .setRepresentations(ResourceRepresentations.newBuilder()
+                        .setMetadata(RepresentationMetadata.newBuilder()
+                                .setLocalResourceId(saved.getId())
+                                .setApiHref(baseUrl + "/api/tasks/" + saved.getId())
+                                .build())
+                        .setCommon(Struct.newBuilder()
+                                .putAllFields(Map.of(
+                                        "workspace_id", Value.newBuilder()
+                                                .setStringValue(saved.getWorkspaceId()).build()))
+                                .build())
+                        .setReporter(Struct.newBuilder()
+                                .putAllFields(Map.of(
+                                        "title", Value.newBuilder()
+                                                .setStringValue(saved.getTitle()).build(),
+                                        "status", Value.newBuilder()
+                                                .setStringValue(saved.getStatus()).build()))
+                                .build())
+                        .build())
+                .build();
+
+        try {
+            kesselClient.reportResource(request);
+        } catch (StatusRuntimeException e) {
+            // Log but don't fail. The resource exists in your database;
+            // Kessel will catch up on the next report or reconciliation.
+            logger.log(Level.WARNING, "kessel: failed to report task " + saved.getId(), e);
+        }
+
+        return saved;
+    }
+}
+//#endregion
+
+//#region check-middleware
+public class KesselAuthInterceptor implements ServerInterceptor {
+    private final KesselInventoryServiceBlockingStub kesselClient;
+    private final String resourceType;
+    private final String reporterType;
+    private final String relation;
+
+    public KesselAuthInterceptor(
+            KesselInventoryServiceBlockingStub kesselClient,
+            String resourceType, String reporterType, String relation) {
+        this.kesselClient = kesselClient;
+        this.resourceType = resourceType;
+        this.reporterType = reporterType;
+        this.relation = relation;
+    }
+
+    @Override
+    public <ReqT, RespT> ServerCall.Listener<ReqT> interceptCall(
+            ServerCall<ReqT, RespT> call, Metadata headers,
+            ServerCallHandler<ReqT, RespT> next) {
+
+        String userId = headers.get(Metadata.Key.of("x-user-id", Metadata.ASCII_STRING_MARSHALLER));
+        String resourceId = headers.get(Metadata.Key.of("x-resource-id", Metadata.ASCII_STRING_MARSHALLER));
+
+        if (userId == null) {
+            call.close(Status.PERMISSION_DENIED.withDescription("missing user identity"), new Metadata());
+            return new ServerCall.Listener<>() {};
+        }
+
+        CheckRequest checkRequest = CheckRequest.newBuilder()
+                .setObject(ResourceReference.newBuilder()
+                        .setResourceType(resourceType)
+                        .setResourceId(resourceId)
+                        .setReporter(ReporterReference.newBuilder().setType(reporterType).build())
+                        .build())
+                .setRelation(relation)
+                .setSubject(SubjectReference.newBuilder()
+                        .setResource(ResourceReference.newBuilder()
+                                .setResourceType("principal")
+                                .setResourceId(userId)
+                                .setReporter(ReporterReference.newBuilder().setType("rbac").build())
+                                .build())
+                        .build())
+                .build();
+
+        try {
+            CheckResponse response = kesselClient.check(checkRequest);
+            if (response.getAllowed() != Allowed.ALLOWED_TRUE) {
+                call.close(Status.PERMISSION_DENIED.withDescription("forbidden"), new Metadata());
+                return new ServerCall.Listener<>() {};
+            }
+        } catch (StatusRuntimeException e) {
+            if (e.getStatus().getCode() == Status.Code.UNAVAILABLE) {
+                call.close(Status.UNAVAILABLE.withDescription("authorization service unavailable"), new Metadata());
+            } else {
+                call.close(Status.PERMISSION_DENIED.withDescription("forbidden"), new Metadata());
+            }
+            return new ServerCall.Listener<>() {};
+        }
+
+        return next.startCall(call, headers);
+    }
+}
+
+// Wire it up when creating the gRPC server:
+//
+//   ServerInterceptor viewAuth = new KesselAuthInterceptor(kesselClient, "task", "TASKMANAGER", "view");
+//   ServerInterceptor editAuth = new KesselAuthInterceptor(kesselClient, "task", "TASKMANAGER", "edit");
+//
+//   Server server = ServerBuilder.forPort(8080)
+//       .addService(ServerInterceptors.intercept(taskService, viewAuth))
+//       .build();
+//#endregion
+
+// Type stubs for compilation context.
+interface TaskRepository { Task insertTask(Task task); void deleteTask(String id); }
+class Task {
+    private String id, workspaceId, title, status;
+    public String getId() { return id; }
+    public String getWorkspaceId() { return workspaceId; }
+    public String getTitle() { return title; }
+    public String getStatus() { return status; }
+}

--- a/src/examples/integrate/example.py
+++ b/src/examples/integrate/example.py
@@ -1,0 +1,155 @@
+import logging
+import os
+
+import grpc
+from google.protobuf import struct_pb2
+from kessel.auth import OAuth2ClientCredentials, fetch_oidc_discovery
+from kessel.inventory.v1beta2 import (
+    ClientBuilder,
+    check_request_pb2,
+    report_resource_request_pb2,
+    reporter_reference_pb2,
+    representation_metadata_pb2,
+    resource_reference_pb2,
+    resource_representations_pb2,
+    subject_reference_pb2,
+)
+
+logger = logging.getLogger(__name__)
+
+# region client-setup
+def create_kessel_client():
+    discovery = fetch_oidc_discovery(os.getenv("KESSEL_ISSUER_URL"))
+
+    auth_credentials = OAuth2ClientCredentials(
+        client_id=os.getenv("KESSEL_CLIENT_ID"),
+        client_secret=os.getenv("KESSEL_CLIENT_SECRET"),
+        token_endpoint=discovery.token_endpoint,
+    )
+
+    with open(os.getenv("KESSEL_CA_CERT_PATH"), "rb") as f:
+        ca_cert = f.read()
+    ssl_credentials = grpc.ssl_channel_credentials(root_certificates=ca_cert)
+
+    stub, channel = (
+        ClientBuilder(os.getenv("KESSEL_ENDPOINT"))
+        .oauth2_client_authenticated(auth_credentials, ssl_credentials)
+        .build()
+    )
+    return stub, channel
+# endregion
+
+
+# region report-on-create
+class TaskServicer:
+    """gRPC servicer for the Task service."""
+
+    def __init__(self, kessel_stub, db, instance_id="taskmanager-1"):
+        self.kessel_stub = kessel_stub
+        self.db = db
+        self.instance_id = instance_id
+
+    def CreateTask(self, request, context):
+        # --- Your existing service logic ---
+        task = self.db.insert_task(request)
+
+        # --- Report to Kessel ---
+        common = struct_pb2.Struct()
+        common.update({"workspace_id": task.workspace_id})
+
+        reporter_data = struct_pb2.Struct()
+        reporter_data.update({"title": task.title, "status": task.status})
+
+        try:
+            self.kessel_stub.ReportResource(
+                report_resource_request_pb2.ReportResourceRequest(
+                    type="task",
+                    reporter_type="TASKMANAGER",
+                    reporter_instance_id=self.instance_id,
+                    representations=resource_representations_pb2.ResourceRepresentations(
+                        metadata=representation_metadata_pb2.RepresentationMetadata(
+                            local_resource_id=task.id,
+                            api_href=f"{os.getenv('BASE_URL')}/api/tasks/{task.id}",
+                        ),
+                        common=common,
+                        reporter=reporter_data,
+                    ),
+                )
+            )
+        except grpc.RpcError as e:
+            # Log but don't fail. The resource exists in your database;
+            # Kessel will catch up on the next report or reconciliation.
+            logger.warning("kessel: failed to report task %s: %s - %s", task.id, e.code(), e.details())
+
+        return task
+# endregion
+
+
+# region check-middleware
+class KesselAuthInterceptor(grpc.ServerInterceptor):
+    """gRPC server interceptor that checks Kessel permissions before the handler runs."""
+
+    def __init__(self, kessel_stub, resource_type, reporter_type, relation):
+        self.kessel_stub = kessel_stub
+        self.resource_type = resource_type
+        self.reporter_type = reporter_type
+        self.relation = relation
+
+    def intercept_service(self, continuation, handler_call_details):
+        handler = continuation(handler_call_details)
+        if handler is None:
+            return None
+
+        metadata = dict(handler_call_details.invocation_metadata)
+        user_id = metadata.get("x-user-id")
+        resource_id = metadata.get("x-resource-id")
+
+        if not user_id:
+            return grpc.unary_unary_rpc_method_handler(
+                lambda req, ctx: ctx.abort(grpc.StatusCode.PERMISSION_DENIED, "missing user identity")
+            )
+
+        try:
+            response = self.kessel_stub.Check(
+                check_request_pb2.CheckRequest(
+                    object=resource_reference_pb2.ResourceReference(
+                        resource_type=self.resource_type,
+                        resource_id=resource_id,
+                        reporter=reporter_reference_pb2.ReporterReference(type=self.reporter_type),
+                    ),
+                    relation=self.relation,
+                    subject=subject_reference_pb2.SubjectReference(
+                        resource=resource_reference_pb2.ResourceReference(
+                            resource_type="principal",
+                            resource_id=user_id,
+                            reporter=reporter_reference_pb2.ReporterReference(type="rbac"),
+                        ),
+                    ),
+                )
+            )
+        except grpc.RpcError as e:
+            if e.code() == grpc.StatusCode.UNAVAILABLE:
+                return grpc.unary_unary_rpc_method_handler(
+                    lambda req, ctx: ctx.abort(grpc.StatusCode.UNAVAILABLE, "authorization service unavailable")
+                )
+            return grpc.unary_unary_rpc_method_handler(
+                lambda req, ctx: ctx.abort(grpc.StatusCode.PERMISSION_DENIED, "forbidden")
+            )
+
+        if response.allowed != 1:  # ALLOWED_TRUE
+            return grpc.unary_unary_rpc_method_handler(
+                lambda req, ctx: ctx.abort(grpc.StatusCode.PERMISSION_DENIED, "forbidden")
+            )
+
+        return handler
+
+# Wire it up when creating the gRPC server:
+#
+#   view_interceptor = KesselAuthInterceptor(kessel_stub, "task", "TASKMANAGER", "view")
+#   edit_interceptor = KesselAuthInterceptor(kessel_stub, "task", "TASKMANAGER", "edit")
+#
+#   server = grpc.server(
+#       futures.ThreadPoolExecutor(max_workers=10),
+#       interceptors=[view_interceptor],
+#   )
+# endregion

--- a/src/examples/integrate/example.py
+++ b/src/examples/integrate/example.py
@@ -3,7 +3,6 @@ import os
 
 import grpc
 from google.protobuf import struct_pb2
-from kessel.auth import OAuth2ClientCredentials, fetch_oidc_discovery
 from kessel.inventory.v1beta2 import (
     ClientBuilder,
     check_request_pb2,
@@ -14,26 +13,15 @@ from kessel.inventory.v1beta2 import (
     resource_representations_pb2,
     subject_reference_pb2,
 )
+from kessel.inventory.v1beta2 import allowed_pb2
 
 logger = logging.getLogger(__name__)
 
 # region client-setup
 def create_kessel_client():
-    discovery = fetch_oidc_discovery(os.getenv("KESSEL_ISSUER_URL"))
-
-    auth_credentials = OAuth2ClientCredentials(
-        client_id=os.getenv("KESSEL_CLIENT_ID"),
-        client_secret=os.getenv("KESSEL_CLIENT_SECRET"),
-        token_endpoint=discovery.token_endpoint,
-    )
-
-    with open(os.getenv("KESSEL_CA_CERT_PATH"), "rb") as f:
-        ca_cert = f.read()
-    ssl_credentials = grpc.ssl_channel_credentials(root_certificates=ca_cert)
-
     stub, channel = (
         ClientBuilder(os.getenv("KESSEL_ENDPOINT"))
-        .oauth2_client_authenticated(auth_credentials, ssl_credentials)
+        .insecure()
         .build()
     )
     return stub, channel
@@ -136,7 +124,7 @@ class KesselAuthInterceptor(grpc.ServerInterceptor):
                 lambda req, ctx: ctx.abort(grpc.StatusCode.PERMISSION_DENIED, "forbidden")
             )
 
-        if response.allowed != 1:  # ALLOWED_TRUE
+        if response.allowed != allowed_pb2.ALLOWED_TRUE:
             return grpc.unary_unary_rpc_method_handler(
                 lambda req, ctx: ctx.abort(grpc.StatusCode.PERMISSION_DENIED, "forbidden")
             )

--- a/src/examples/integrate/example.rb
+++ b/src/examples/integrate/example.rb
@@ -1,0 +1,111 @@
+require 'kessel-sdk'
+require 'json'
+
+include Kessel::Inventory::V1beta2
+
+# region client-setup
+def create_kessel_client
+  builder = KesselInventoryService::ClientBuilder.new(ENV.fetch('KESSEL_ENDPOINT', nil))
+  builder.insecure.build
+end
+# endregion
+
+# region report-on-create
+class TaskServicer
+  def initialize(kessel_client, db, instance_id: nil)
+    @kessel_client = kessel_client
+    @db = db
+    @instance_id = instance_id || ENV.fetch('REPORTER_INSTANCE_ID', 'taskmanager-1')
+    @base_url = ENV.fetch('BASE_URL', 'http://localhost:8080')
+  end
+
+  def create_task(request, _call)
+    # --- Your existing service logic ---
+    task = @db.insert_task(request)
+
+    # --- Report to Kessel ---
+    common = Google::Protobuf::Struct.decode_json({ 'workspace_id' => task.workspace_id }.to_json)
+    reporter_data = Google::Protobuf::Struct.decode_json(
+      { 'title' => task.title, 'status' => task.status }.to_json
+    )
+
+    begin
+      @kessel_client.report_resource(
+        ReportResourceRequest.new(
+          type: 'task',
+          reporter_type: 'TASKMANAGER',
+          reporter_instance_id: @instance_id,
+          representations: ResourceRepresentations.new(
+            metadata: RepresentationMetadata.new(
+              local_resource_id: task.id,
+              api_href: "#{@base_url}/api/tasks/#{task.id}"
+            ),
+            common: common,
+            reporter: reporter_data
+          )
+        )
+      )
+    rescue GRPC::BadStatus => e
+      # Log but don't fail. The resource exists in your database;
+      # Kessel will catch up on the next report or reconciliation.
+      warn "kessel: failed to report task #{task.id}: #{e.message}"
+    end
+
+    task
+  end
+end
+# endregion
+
+# region check-middleware
+class KesselAuthInterceptor < GRPC::ServerInterceptor
+  def initialize(kessel_client, resource_type, reporter_type, relation)
+    @kessel_client = kessel_client
+    @resource_type = resource_type
+    @reporter_type = reporter_type
+    @relation = relation
+  end
+
+  def request_response(request:, call:, method:)
+    user_id = call.metadata['x-user-id']
+    resource_id = call.metadata['x-resource-id']
+
+    raise GRPC::PermissionDenied, 'missing user identity' unless user_id
+
+    response = @kessel_client.check(
+      CheckRequest.new(
+        object: ResourceReference.new(
+          resource_type: @resource_type,
+          resource_id: resource_id,
+          reporter: ReporterReference.new(type: @reporter_type)
+        ),
+        relation: @relation,
+        subject: SubjectReference.new(
+          resource: ResourceReference.new(
+            resource_type: 'principal',
+            resource_id: user_id,
+            reporter: ReporterReference.new(type: 'rbac')
+          )
+        )
+      )
+    )
+
+    raise GRPC::PermissionDenied, 'forbidden' unless response.allowed == Allowed::ALLOWED_TRUE
+
+    yield
+  rescue GRPC::Unavailable
+    raise GRPC::Unavailable, 'authorization service unavailable'
+  rescue GRPC::BadStatus
+    raise GRPC::PermissionDenied, 'forbidden'
+  end
+end
+
+# Wire it up when creating the gRPC server:
+#
+#   view_interceptor = KesselAuthInterceptor.new(kessel_client, 'task', 'TASKMANAGER', 'view')
+#   edit_interceptor = KesselAuthInterceptor.new(kessel_client, 'task', 'TASKMANAGER', 'edit')
+#
+#   server = GRPC::RpcServer.new(interceptors: [view_interceptor])
+#   server.add_http2_port('0.0.0.0:8080', :this_port_is_insecure)
+#   server.handle(TaskServicer.new(kessel_client, db))
+#   server.run_till_terminated
+# endregion

--- a/src/examples/integrate/example.ts
+++ b/src/examples/integrate/example.ts
@@ -1,6 +1,5 @@
-import { readFileSync } from "fs";
 import { ClientBuilder } from "@project-kessel/kessel-sdk/kessel/inventory/v1beta2";
-import { fetchOIDCDiscovery, OAuth2ClientCredentials } from "@project-kessel/kessel-sdk/kessel/auth";
+import { Allowed } from "@project-kessel/kessel-sdk/kessel/inventory/v1beta2/allowed";
 import type { CheckRequest } from "@project-kessel/kessel-sdk/kessel/inventory/v1beta2/check_request";
 import type { ReportResourceRequest } from "@project-kessel/kessel-sdk/kessel/inventory/v1beta2/report_resource_request";
 import type {
@@ -10,23 +9,12 @@ import type {
     Metadata,
     ServerInterceptingCall,
 } from "@grpc/grpc-js";
-import { credentials, status as grpcStatus } from "@grpc/grpc-js";
+import { status as grpcStatus } from "@grpc/grpc-js";
 
 //#region client-setup
 async function createKesselClient() {
-    const discovery = await fetchOIDCDiscovery(process.env.KESSEL_ISSUER_URL!);
-
-    const auth = new OAuth2ClientCredentials({
-        clientId: process.env.KESSEL_CLIENT_ID!,
-        clientSecret: process.env.KESSEL_CLIENT_SECRET!,
-        tokenEndpoint: discovery.tokenEndpoint,
-    });
-
-    const caCert = readFileSync(process.env.KESSEL_CA_CERT_PATH!);
-    const tlsCreds = credentials.createSsl(caCert);
-
     return new ClientBuilder(process.env.KESSEL_ENDPOINT!)
-        .oauth2ClientAuthenticated(auth, tlsCreds)
+        .insecure()
         .buildAsync();
 }
 //#endregion
@@ -110,7 +98,7 @@ function kesselAuthInterceptor(
 
         try {
             const response = await kesselClient.check(checkRequest);
-            if (response.allowed !== 1) { // ALLOWED_TRUE
+            if (response.allowed !== Allowed.ALLOWED_TRUE) {
                 call.sendStatus({
                     code: grpcStatus.PERMISSION_DENIED,
                     details: "forbidden",

--- a/src/examples/integrate/example.ts
+++ b/src/examples/integrate/example.ts
@@ -1,0 +1,135 @@
+import { ClientBuilder } from "@project-kessel/kessel-sdk/kessel/inventory/v1beta2";
+import type { CheckRequest } from "@project-kessel/kessel-sdk/kessel/inventory/v1beta2/check_request";
+import type { ReportResourceRequest } from "@project-kessel/kessel-sdk/kessel/inventory/v1beta2/report_resource_request";
+import type {
+    ServerUnaryCall,
+    sendUnaryData,
+    handleUnaryCall,
+    Metadata,
+    UntypedHandleCall,
+    ServerInterceptingCall,
+} from "@grpc/grpc-js";
+import { status as grpcStatus } from "@grpc/grpc-js";
+
+//#region client-setup
+// For production, configure OAuth2 + TLS.
+// The TypeScript SDK uses the same builder pattern as Go and Python.
+// If your environment provides a bearer token directly (e.g., a sidecar),
+// pass it as a call credential. Otherwise, configure OAuth2 as shown
+// in the Go and Python examples and the Enable TLS guide.
+const client = new ClientBuilder(process.env.KESSEL_ENDPOINT!)
+    .insecure() // Replace with .authenticated() when TLS/OAuth2 support is available
+    .buildAsync();
+//#endregion
+
+//#region report-on-create
+const createTask: handleUnaryCall<CreateTaskRequest, CreateTaskResponse> = async (
+    call: ServerUnaryCall<CreateTaskRequest, CreateTaskResponse>,
+    callback: sendUnaryData<CreateTaskResponse>
+) => {
+    // --- Your existing service logic ---
+    const task = await db.insertTask(call.request);
+
+    // --- Report to Kessel ---
+    const reportRequest: ReportResourceRequest = {
+        type: "task",
+        reporterType: "TASKMANAGER",
+        reporterInstanceId: process.env.REPORTER_INSTANCE_ID ?? "taskmanager-1",
+        representations: {
+            metadata: {
+                localResourceId: task.id,
+                apiHref: `${process.env.BASE_URL}/api/tasks/${task.id}`,
+            },
+            common: { workspace_id: task.workspaceId },
+            reporter: { title: task.title, status: task.status },
+        },
+    };
+
+    try {
+        await client.reportResource(reportRequest);
+    } catch (err) {
+        // Log but don't fail. The resource exists in your database;
+        // Kessel will catch up on the next report or reconciliation.
+        console.warn(`kessel: failed to report task ${task.id}:`, err);
+    }
+
+    callback(null, { task });
+};
+//#endregion
+
+//#region check-middleware
+function kesselAuthInterceptor(
+    kesselClient: typeof client,
+    resourceType: string,
+    reporterType: string,
+    relation: string
+) {
+    return async function intercept(
+        call: ServerInterceptingCall,
+        methodDefinition: any,
+        next: Function
+    ) {
+        const metadata: Metadata = call.metadata;
+        const userIds = metadata.get("x-user-id");
+        const resourceIds = metadata.get("x-resource-id");
+
+        if (!userIds.length) {
+            call.sendStatus({
+                code: grpcStatus.PERMISSION_DENIED,
+                details: "missing user identity",
+            });
+            return;
+        }
+
+        const checkRequest: CheckRequest = {
+            object: {
+                resourceType,
+                resourceId: String(resourceIds[0]),
+                reporter: { type: reporterType },
+            },
+            relation,
+            subject: {
+                resource: {
+                    resourceType: "principal",
+                    resourceId: String(userIds[0]),
+                    reporter: { type: "rbac" },
+                },
+            },
+        };
+
+        try {
+            const response = await kesselClient.check(checkRequest);
+            if (response.allowed !== 1) { // ALLOWED_TRUE
+                call.sendStatus({
+                    code: grpcStatus.PERMISSION_DENIED,
+                    details: "forbidden",
+                });
+                return;
+            }
+        } catch {
+            call.sendStatus({
+                code: grpcStatus.PERMISSION_DENIED,
+                details: "forbidden",
+            });
+            return;
+        }
+
+        next();
+    };
+}
+
+// Wire it up when creating the gRPC server:
+//
+//   const server = new grpc.Server({
+//       interceptors: [
+//           kesselAuthInterceptor(kesselClient, "task", "TASKMANAGER", "view"),
+//       ],
+//   });
+//   server.addService(TaskServiceDefinition, { createTask });
+//#endregion
+
+// Type stubs for compilation context.
+interface CreateTaskRequest { title: string; workspaceId: string }
+interface CreateTaskResponse { task: Task }
+interface Task { id: string; workspaceId: string; title: string; status: string }
+const db = { insertTask: async (req: CreateTaskRequest): Promise<Task> => ({} as Task) };

--- a/src/examples/integrate/main.go
+++ b/src/examples/integrate/main.go
@@ -142,19 +142,15 @@ func (s *TaskService) DeleteTask(ctx context.Context, req *DeleteTaskRequest) (*
 		return nil, status.Errorf(codes.Internal, "delete task: %v", err)
 	}
 
-	_, err := s.kessel.ReportResource(ctx, &v1beta2.ReportResourceRequest{
-		Type:               "task",
-		ReporterType:       "TASKMANAGER",
-		ReporterInstanceId: s.instanceID,
-		Representations: &v1beta2.ResourceRepresentations{
-			Metadata: &v1beta2.RepresentationMetadata{
-				LocalResourceId: req.ID,
-				ResourceDeleted: true,
-			},
+	_, err := s.kessel.DeleteResource(ctx, &v1beta2.DeleteResourceRequest{
+		Reference: &v1beta2.ResourceReference{
+			ResourceType: "task",
+			ResourceId:   req.ID,
+			Reporter:     &v1beta2.ReporterReference{Type: "TASKMANAGER"},
 		},
 	})
 	if err != nil {
-		log.Printf("kessel: failed to report task deletion %s: %v", req.ID, err)
+		log.Printf("kessel: failed to delete task %s: %v", req.ID, err)
 	}
 
 	return &DeleteTaskResponse{}, nil

--- a/src/examples/integrate/main.go
+++ b/src/examples/integrate/main.go
@@ -1,0 +1,247 @@
+package main
+
+import (
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+	"log"
+	"net"
+	"os"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/types/known/structpb"
+
+	"github.com/project-kessel/kessel-sdk-go/kessel/auth"
+	kesselgrpc "github.com/project-kessel/kessel-sdk-go/kessel/grpc"
+	"github.com/project-kessel/kessel-sdk-go/kessel/inventory/v1beta2"
+)
+
+// TaskService implements your application's gRPC service.
+type TaskService struct {
+	kessel     v1beta2.KesselInventoryServiceClient
+	db         *DB
+	instanceID string
+	baseURL    string
+}
+
+func main() {
+	// --- Create the Kessel client ---
+	kesselClient, cleanup, err := newKesselClient()
+	if err != nil {
+		log.Fatalf("kessel client: %v", err)
+	}
+	defer cleanup()
+
+	// --- Set up gRPC server with Kessel auth interceptor ---
+	viewAuth := KesselAuthInterceptor(kesselClient, "task", "TASKMANAGER", "view")
+	editAuth := KesselAuthInterceptor(kesselClient, "task", "TASKMANAGER", "edit")
+
+	server := grpc.NewServer(
+		grpc.ChainUnaryInterceptor(
+			routeInterceptor(map[string]grpc.UnaryServerInterceptor{
+				"/taskmanager.TaskService/GetTask":    viewAuth,
+				"/taskmanager.TaskService/UpdateTask": editAuth,
+			}),
+		),
+	)
+
+	svc := &TaskService{
+		kessel:     kesselClient,
+		db:         &DB{},
+		instanceID: envOrDefault("REPORTER_INSTANCE_ID", "taskmanager-1"),
+		baseURL:    envOrDefault("BASE_URL", "http://localhost:8080"),
+	}
+
+	// Register your service with the gRPC server.
+	// In a real project this would be the generated registration function:
+	//   taskpb.RegisterTaskServiceServer(server, svc)
+	_ = svc
+
+	lis, err := net.Listen("tcp", ":8080")
+	if err != nil {
+		log.Fatalf("listen: %v", err)
+	}
+	log.Println("serving on :8080")
+	if err := server.Serve(lis); err != nil {
+		log.Fatalf("serve: %v", err)
+	}
+}
+
+// newKesselClient creates an authenticated Kessel Inventory client
+// using OAuth2 credentials and TLS.
+func newKesselClient() (v1beta2.KesselInventoryServiceClient, func(), error) {
+	oauthCreds := auth.NewOAuth2ClientCredentials(
+		os.Getenv("KESSEL_CLIENT_ID"),
+		os.Getenv("KESSEL_CLIENT_SECRET"),
+		os.Getenv("KESSEL_TOKEN_ENDPOINT"),
+	)
+
+	caCert, err := os.ReadFile(os.Getenv("KESSEL_CA_CERT_PATH"))
+	if err != nil {
+		return nil, nil, fmt.Errorf("read CA cert: %w", err)
+	}
+	certPool := x509.NewCertPool()
+	certPool.AppendCertsFromPEM(caCert)
+	tlsCreds := credentials.NewTLS(&tls.Config{RootCAs: certPool})
+
+	client, conn, err := v1beta2.NewClientBuilder(os.Getenv("KESSEL_ENDPOINT")).
+		Authenticated(kesselgrpc.OAuth2CallCredentials(&oauthCreds), tlsCreds).
+		Build()
+	if err != nil {
+		return nil, nil, fmt.Errorf("build client: %w", err)
+	}
+	return client, func() { conn.Close() }, nil
+}
+
+// CreateTask handles task creation. After writing to the database,
+// it reports the new resource to Kessel.
+func (s *TaskService) CreateTask(ctx context.Context, req *CreateTaskRequest) (*CreateTaskResponse, error) {
+	task, err := s.db.InsertTask(ctx, req)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "insert task: %v", err)
+	}
+
+	_, err = s.kessel.ReportResource(ctx, &v1beta2.ReportResourceRequest{
+		Type:               "task",
+		ReporterType:       "TASKMANAGER",
+		ReporterInstanceId: s.instanceID,
+		Representations: &v1beta2.ResourceRepresentations{
+			Metadata: &v1beta2.RepresentationMetadata{
+				LocalResourceId: task.ID,
+				ApiHref:         fmt.Sprintf("%s/api/tasks/%s", s.baseURL, task.ID),
+			},
+			Common: &structpb.Struct{
+				Fields: map[string]*structpb.Value{
+					"workspace_id": structpb.NewStringValue(task.WorkspaceID),
+				},
+			},
+			Reporter: &structpb.Struct{
+				Fields: map[string]*structpb.Value{
+					"title":  structpb.NewStringValue(task.Title),
+					"status": structpb.NewStringValue(task.Status),
+				},
+			},
+		},
+	})
+	if err != nil {
+		log.Printf("kessel: failed to report task %s: %v", task.ID, err)
+	}
+
+	return &CreateTaskResponse{Task: task}, nil
+}
+
+// DeleteTask handles task deletion. After removing the resource from the
+// database, it reports the deletion to Kessel.
+func (s *TaskService) DeleteTask(ctx context.Context, req *DeleteTaskRequest) (*DeleteTaskResponse, error) {
+	if err := s.db.DeleteTask(ctx, req.ID); err != nil {
+		return nil, status.Errorf(codes.Internal, "delete task: %v", err)
+	}
+
+	_, err := s.kessel.ReportResource(ctx, &v1beta2.ReportResourceRequest{
+		Type:               "task",
+		ReporterType:       "TASKMANAGER",
+		ReporterInstanceId: s.instanceID,
+		Representations: &v1beta2.ResourceRepresentations{
+			Metadata: &v1beta2.RepresentationMetadata{
+				LocalResourceId: req.ID,
+				ResourceDeleted: true,
+			},
+		},
+	})
+	if err != nil {
+		log.Printf("kessel: failed to report task deletion %s: %v", req.ID, err)
+	}
+
+	return &DeleteTaskResponse{}, nil
+}
+
+// KesselAuthInterceptor returns a gRPC server interceptor that checks
+// Kessel permissions before forwarding the call to the handler.
+func KesselAuthInterceptor(client v1beta2.KesselInventoryServiceClient, resourceType, reporterType, relation string) grpc.UnaryServerInterceptor {
+	return func(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {
+		md, ok := metadata.FromIncomingContext(ctx)
+		if !ok {
+			return nil, status.Error(codes.PermissionDenied, "missing metadata")
+		}
+
+		userIDs := md.Get("x-user-id")
+		if len(userIDs) == 0 {
+			return nil, status.Error(codes.PermissionDenied, "missing user identity")
+		}
+
+		resourceID := extractResourceID(req)
+
+		resp, err := client.Check(ctx, &v1beta2.CheckRequest{
+			Object: &v1beta2.ResourceReference{
+				ResourceType: resourceType,
+				ResourceId:   resourceID,
+				Reporter:     &v1beta2.ReporterReference{Type: reporterType},
+			},
+			Relation: relation,
+			Subject: &v1beta2.SubjectReference{
+				Resource: &v1beta2.ResourceReference{
+					ResourceType: "principal",
+					ResourceId:   userIDs[0],
+					Reporter:     &v1beta2.ReporterReference{Type: "rbac"},
+				},
+			},
+		})
+		if err != nil {
+			if st, ok := status.FromError(err); ok && st.Code() == codes.Unavailable {
+				return nil, status.Error(codes.Unavailable, "authorization service unavailable")
+			}
+			return nil, status.Error(codes.PermissionDenied, "forbidden")
+		}
+
+		if resp.Allowed != v1beta2.Allowed_ALLOWED_TRUE {
+			return nil, status.Error(codes.PermissionDenied, "forbidden")
+		}
+
+		return handler(ctx, req)
+	}
+}
+
+// routeInterceptor dispatches to per-method interceptors based on the
+// full gRPC method name. Methods without a mapping pass through directly.
+func routeInterceptor(routes map[string]grpc.UnaryServerInterceptor) grpc.UnaryServerInterceptor {
+	return func(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {
+		if interceptor, ok := routes[info.FullMethod]; ok {
+			return interceptor(ctx, req, info, handler)
+		}
+		return handler(ctx, req)
+	}
+}
+
+func envOrDefault(key, fallback string) string {
+	if v := os.Getenv(key); v != "" {
+		return v
+	}
+	return fallback
+}
+
+// Stubs below stand in for your protobuf-generated types and database layer.
+type CreateTaskRequest struct {
+	Title       string
+	WorkspaceID string
+}
+type CreateTaskResponse struct{ Task Task }
+type DeleteTaskRequest struct{ ID string }
+type DeleteTaskResponse struct{}
+type Task struct {
+	ID          string
+	WorkspaceID string
+	Title       string
+	Status      string
+}
+type DB struct{}
+
+func (db *DB) InsertTask(ctx context.Context, req *CreateTaskRequest) (Task, error) {
+	return Task{}, nil
+}
+func (db *DB) DeleteTask(ctx context.Context, id string) error { return nil }
+func extractResourceID(req interface{}) string                 { return "" }

--- a/src/examples/integrate/main.go
+++ b/src/examples/integrate/main.go
@@ -2,8 +2,6 @@ package main
 
 import (
 	"context"
-	"crypto/tls"
-	"crypto/x509"
 	"fmt"
 	"log"
 	"net"
@@ -11,13 +9,10 @@ import (
 
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/structpb"
 
-	"github.com/project-kessel/kessel-sdk-go/kessel/auth"
-	kesselgrpc "github.com/project-kessel/kessel-sdk-go/kessel/grpc"
 	"github.com/project-kessel/kessel-sdk-go/kessel/inventory/v1beta2"
 )
 
@@ -72,25 +67,9 @@ func main() {
 	}
 }
 
-// newKesselClient creates an authenticated Kessel Inventory client
-// using OAuth2 credentials and TLS.
 func newKesselClient() (v1beta2.KesselInventoryServiceClient, func(), error) {
-	oauthCreds := auth.NewOAuth2ClientCredentials(
-		os.Getenv("KESSEL_CLIENT_ID"),
-		os.Getenv("KESSEL_CLIENT_SECRET"),
-		os.Getenv("KESSEL_TOKEN_ENDPOINT"),
-	)
-
-	caCert, err := os.ReadFile(os.Getenv("KESSEL_CA_CERT_PATH"))
-	if err != nil {
-		return nil, nil, fmt.Errorf("read CA cert: %w", err)
-	}
-	certPool := x509.NewCertPool()
-	certPool.AppendCertsFromPEM(caCert)
-	tlsCreds := credentials.NewTLS(&tls.Config{RootCAs: certPool})
-
 	client, conn, err := v1beta2.NewClientBuilder(os.Getenv("KESSEL_ENDPOINT")).
-		Authenticated(kesselgrpc.OAuth2CallCredentials(&oauthCreds), tlsCreds).
+		Insecure().
 		Build()
 	if err != nil {
 		return nil, nil, fmt.Errorf("build client: %w", err)

--- a/src/examples/integrate/main.java
+++ b/src/examples/integrate/main.java
@@ -1,0 +1,225 @@
+package com.example.taskmanager;
+
+import com.google.protobuf.Struct;
+import com.google.protobuf.Value;
+import com.nimbusds.jose.util.Pair;
+import io.grpc.*;
+import org.project_kessel.api.inventory.v1beta2.*;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import static org.project_kessel.api.inventory.v1beta2.KesselInventoryServiceGrpc.KesselInventoryServiceBlockingStub;
+
+// ---------------------------------------------------------------------------
+// Kessel client
+// ---------------------------------------------------------------------------
+
+class KesselClientFactory {
+    static Pair<KesselInventoryServiceBlockingStub, ManagedChannel> createKesselClient() {
+        return new ClientBuilder(System.getenv("KESSEL_ENDPOINT"))
+                .insecure()
+                .build();
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Task service
+// ---------------------------------------------------------------------------
+
+class TaskService {
+    private static final Logger logger = Logger.getLogger(TaskService.class.getName());
+    private final KesselInventoryServiceBlockingStub kesselClient;
+    private final TaskRepository db;
+    private final String instanceId;
+    private final String baseUrl;
+
+    TaskService(KesselInventoryServiceBlockingStub kesselClient, TaskRepository db) {
+        this.kesselClient = kesselClient;
+        this.db = db;
+        this.instanceId = System.getenv().getOrDefault("REPORTER_INSTANCE_ID", "taskmanager-1");
+        this.baseUrl = System.getenv().getOrDefault("BASE_URL", "http://localhost:8080");
+    }
+
+    Task createTask(Task task) {
+        Task saved = db.insertTask(task);
+
+        ReportResourceRequest request = ReportResourceRequest.newBuilder()
+                .setType("task")
+                .setReporterType("TASKMANAGER")
+                .setReporterInstanceId(instanceId)
+                .setRepresentations(ResourceRepresentations.newBuilder()
+                        .setMetadata(RepresentationMetadata.newBuilder()
+                                .setLocalResourceId(saved.getId())
+                                .setApiHref(baseUrl + "/api/tasks/" + saved.getId())
+                                .build())
+                        .setCommon(Struct.newBuilder()
+                                .putAllFields(Map.of(
+                                        "workspace_id", Value.newBuilder()
+                                                .setStringValue(saved.getWorkspaceId()).build()))
+                                .build())
+                        .setReporter(Struct.newBuilder()
+                                .putAllFields(Map.of(
+                                        "title", Value.newBuilder()
+                                                .setStringValue(saved.getTitle()).build(),
+                                        "status", Value.newBuilder()
+                                                .setStringValue(saved.getStatus()).build()))
+                                .build())
+                        .build())
+                .build();
+
+        try {
+            kesselClient.reportResource(request);
+        } catch (StatusRuntimeException e) {
+            logger.log(Level.WARNING, "kessel: failed to report task " + saved.getId(), e);
+        }
+
+        return saved;
+    }
+
+    void deleteTask(String taskId) {
+        db.deleteTask(taskId);
+
+        DeleteResourceRequest request = DeleteResourceRequest.newBuilder()
+                .setReference(ResourceReference.newBuilder()
+                        .setResourceType("task")
+                        .setResourceId(taskId)
+                        .setReporter(ReporterReference.newBuilder().setType("TASKMANAGER").build())
+                        .build())
+                .build();
+
+        try {
+            kesselClient.deleteResource(request);
+        } catch (StatusRuntimeException e) {
+            logger.log(Level.WARNING, "kessel: failed to delete task " + taskId, e);
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Kessel auth interceptor
+// ---------------------------------------------------------------------------
+
+class KesselAuthInterceptor implements ServerInterceptor {
+    private final KesselInventoryServiceBlockingStub kesselClient;
+    private final String resourceType;
+    private final String reporterType;
+    private final String relation;
+
+    KesselAuthInterceptor(
+            KesselInventoryServiceBlockingStub kesselClient,
+            String resourceType, String reporterType, String relation) {
+        this.kesselClient = kesselClient;
+        this.resourceType = resourceType;
+        this.reporterType = reporterType;
+        this.relation = relation;
+    }
+
+    @Override
+    public <ReqT, RespT> ServerCall.Listener<ReqT> interceptCall(
+            ServerCall<ReqT, RespT> call, Metadata headers,
+            ServerCallHandler<ReqT, RespT> next) {
+
+        String userId = headers.get(Metadata.Key.of("x-user-id", Metadata.ASCII_STRING_MARSHALLER));
+        String resourceId = headers.get(Metadata.Key.of("x-resource-id", Metadata.ASCII_STRING_MARSHALLER));
+
+        if (userId == null) {
+            call.close(Status.PERMISSION_DENIED.withDescription("missing user identity"), new Metadata());
+            return new ServerCall.Listener<>() {};
+        }
+
+        CheckRequest checkRequest = CheckRequest.newBuilder()
+                .setObject(ResourceReference.newBuilder()
+                        .setResourceType(resourceType)
+                        .setResourceId(resourceId)
+                        .setReporter(ReporterReference.newBuilder().setType(reporterType).build())
+                        .build())
+                .setRelation(relation)
+                .setSubject(SubjectReference.newBuilder()
+                        .setResource(ResourceReference.newBuilder()
+                                .setResourceType("principal")
+                                .setResourceId(userId)
+                                .setReporter(ReporterReference.newBuilder().setType("rbac").build())
+                                .build())
+                        .build())
+                .build();
+
+        try {
+            CheckResponse response = kesselClient.check(checkRequest);
+            if (response.getAllowed() != Allowed.ALLOWED_TRUE) {
+                call.close(Status.PERMISSION_DENIED.withDescription("forbidden"), new Metadata());
+                return new ServerCall.Listener<>() {};
+            }
+        } catch (StatusRuntimeException e) {
+            if (e.getStatus().getCode() == Status.Code.UNAVAILABLE) {
+                call.close(Status.UNAVAILABLE.withDescription("authorization service unavailable"), new Metadata());
+            } else {
+                call.close(Status.PERMISSION_DENIED.withDescription("forbidden"), new Metadata());
+            }
+            return new ServerCall.Listener<>() {};
+        }
+
+        return next.startCall(call, headers);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Server startup
+// ---------------------------------------------------------------------------
+
+public class Main {
+    private static final Logger logger = Logger.getLogger(Main.class.getName());
+
+    public static void main(String[] args) throws IOException, InterruptedException {
+        Pair<KesselInventoryServiceBlockingStub, ManagedChannel> clientAndChannel =
+                KesselClientFactory.createKesselClient();
+        KesselInventoryServiceBlockingStub kesselClient = clientAndChannel.getLeft();
+        ManagedChannel channel = clientAndChannel.getRight();
+
+        ServerInterceptor viewAuth = new KesselAuthInterceptor(kesselClient, "task", "TASKMANAGER", "view");
+        ServerInterceptor editAuth = new KesselAuthInterceptor(kesselClient, "task", "TASKMANAGER", "edit");
+
+        TaskService taskService = new TaskService(kesselClient, new InMemoryTaskRepository());
+
+        // Register your service with the gRPC server.
+        // In a real project this would use the generated service definition:
+        //   .addService(ServerInterceptors.intercept(taskServiceImpl, viewAuth))
+
+        Server server = ServerBuilder.forPort(8080)
+                .build();
+
+        server.start();
+        logger.info("serving on :8080");
+
+        Runtime.getRuntime().addShutdownHook(new Thread(() -> {
+            server.shutdown();
+            channel.shutdown();
+        }));
+
+        server.awaitTermination();
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Stubs (stand in for your protobuf-generated types and database layer)
+// ---------------------------------------------------------------------------
+
+interface TaskRepository {
+    Task insertTask(Task task);
+    void deleteTask(String id);
+}
+
+class Task {
+    private String id, workspaceId, title, status;
+    public String getId() { return id; }
+    public String getWorkspaceId() { return workspaceId; }
+    public String getTitle() { return title; }
+    public String getStatus() { return status; }
+}
+
+class InMemoryTaskRepository implements TaskRepository {
+    public Task insertTask(Task task) { return task; }
+    public void deleteTask(String id) {}
+}

--- a/src/examples/integrate/main.py
+++ b/src/examples/integrate/main.py
@@ -1,0 +1,229 @@
+import logging
+import os
+from concurrent import futures
+
+import grpc
+from google.protobuf import struct_pb2
+from kessel.auth import OAuth2ClientCredentials, fetch_oidc_discovery
+from kessel.inventory.v1beta2 import (
+    ClientBuilder,
+    check_request_pb2,
+    report_resource_request_pb2,
+    reporter_reference_pb2,
+    representation_metadata_pb2,
+    resource_reference_pb2,
+    resource_representations_pb2,
+    subject_reference_pb2,
+)
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Kessel client
+# ---------------------------------------------------------------------------
+
+def create_kessel_client():
+    """Create an authenticated Kessel Inventory client using OAuth2 and TLS."""
+    discovery = fetch_oidc_discovery(os.getenv("KESSEL_ISSUER_URL"))
+
+    auth_credentials = OAuth2ClientCredentials(
+        client_id=os.getenv("KESSEL_CLIENT_ID"),
+        client_secret=os.getenv("KESSEL_CLIENT_SECRET"),
+        token_endpoint=discovery.token_endpoint,
+    )
+
+    with open(os.getenv("KESSEL_CA_CERT_PATH"), "rb") as f:
+        ca_cert = f.read()
+    ssl_credentials = grpc.ssl_channel_credentials(root_certificates=ca_cert)
+
+    stub, channel = (
+        ClientBuilder(os.getenv("KESSEL_ENDPOINT"))
+        .oauth2_client_authenticated(auth_credentials, ssl_credentials)
+        .build()
+    )
+    return stub, channel
+
+
+# ---------------------------------------------------------------------------
+# Task service
+# ---------------------------------------------------------------------------
+
+class TaskServicer:
+    """gRPC servicer for the Task service."""
+
+    def __init__(self, kessel_stub, db, instance_id=None):
+        self.kessel_stub = kessel_stub
+        self.db = db
+        self.instance_id = instance_id or os.getenv("REPORTER_INSTANCE_ID", "taskmanager-1")
+        self.base_url = os.getenv("BASE_URL", "http://localhost:8080")
+
+    def CreateTask(self, request, context):
+        task = self.db.insert_task(request)
+
+        common = struct_pb2.Struct()
+        common.update({"workspace_id": task.workspace_id})
+
+        reporter_data = struct_pb2.Struct()
+        reporter_data.update({"title": task.title, "status": task.status})
+
+        try:
+            self.kessel_stub.ReportResource(
+                report_resource_request_pb2.ReportResourceRequest(
+                    type="task",
+                    reporter_type="TASKMANAGER",
+                    reporter_instance_id=self.instance_id,
+                    representations=resource_representations_pb2.ResourceRepresentations(
+                        metadata=representation_metadata_pb2.RepresentationMetadata(
+                            local_resource_id=task.id,
+                            api_href=f"{self.base_url}/api/tasks/{task.id}",
+                        ),
+                        common=common,
+                        reporter=reporter_data,
+                    ),
+                )
+            )
+        except grpc.RpcError as e:
+            logger.warning("kessel: failed to report task %s: %s - %s", task.id, e.code(), e.details())
+
+        return task
+
+    def DeleteTask(self, request, context):
+        self.db.delete_task(request.id)
+
+        try:
+            self.kessel_stub.ReportResource(
+                report_resource_request_pb2.ReportResourceRequest(
+                    type="task",
+                    reporter_type="TASKMANAGER",
+                    reporter_instance_id=self.instance_id,
+                    representations=resource_representations_pb2.ResourceRepresentations(
+                        metadata=representation_metadata_pb2.RepresentationMetadata(
+                            local_resource_id=request.id,
+                            resource_deleted=True,
+                        ),
+                    ),
+                )
+            )
+        except grpc.RpcError as e:
+            logger.warning("kessel: failed to report task deletion %s: %s - %s", request.id, e.code(), e.details())
+
+        return DeleteTaskResponse()
+
+
+# ---------------------------------------------------------------------------
+# Kessel auth interceptor
+# ---------------------------------------------------------------------------
+
+class KesselAuthInterceptor(grpc.ServerInterceptor):
+    """gRPC server interceptor that checks Kessel permissions before the handler runs."""
+
+    def __init__(self, kessel_stub, resource_type, reporter_type, relation):
+        self.kessel_stub = kessel_stub
+        self.resource_type = resource_type
+        self.reporter_type = reporter_type
+        self.relation = relation
+
+    def intercept_service(self, continuation, handler_call_details):
+        handler = continuation(handler_call_details)
+        if handler is None:
+            return None
+
+        metadata = dict(handler_call_details.invocation_metadata)
+        user_id = metadata.get("x-user-id")
+        resource_id = metadata.get("x-resource-id")
+
+        if not user_id:
+            return grpc.unary_unary_rpc_method_handler(
+                lambda req, ctx: ctx.abort(grpc.StatusCode.PERMISSION_DENIED, "missing user identity")
+            )
+
+        try:
+            response = self.kessel_stub.Check(
+                check_request_pb2.CheckRequest(
+                    object=resource_reference_pb2.ResourceReference(
+                        resource_type=self.resource_type,
+                        resource_id=resource_id,
+                        reporter=reporter_reference_pb2.ReporterReference(type=self.reporter_type),
+                    ),
+                    relation=self.relation,
+                    subject=subject_reference_pb2.SubjectReference(
+                        resource=resource_reference_pb2.ResourceReference(
+                            resource_type="principal",
+                            resource_id=user_id,
+                            reporter=reporter_reference_pb2.ReporterReference(type="rbac"),
+                        ),
+                    ),
+                )
+            )
+        except grpc.RpcError as e:
+            if e.code() == grpc.StatusCode.UNAVAILABLE:
+                return grpc.unary_unary_rpc_method_handler(
+                    lambda req, ctx: ctx.abort(grpc.StatusCode.UNAVAILABLE, "authorization service unavailable")
+                )
+            return grpc.unary_unary_rpc_method_handler(
+                lambda req, ctx: ctx.abort(grpc.StatusCode.PERMISSION_DENIED, "forbidden")
+            )
+
+        if response.allowed != 1:  # ALLOWED_TRUE
+            return grpc.unary_unary_rpc_method_handler(
+                lambda req, ctx: ctx.abort(grpc.StatusCode.PERMISSION_DENIED, "forbidden")
+            )
+
+        return handler
+
+
+# ---------------------------------------------------------------------------
+# Server startup
+# ---------------------------------------------------------------------------
+
+def serve():
+    kessel_stub, kessel_channel = create_kessel_client()
+    db = DB()
+
+    view_interceptor = KesselAuthInterceptor(kessel_stub, "task", "TASKMANAGER", "view")
+    edit_interceptor = KesselAuthInterceptor(kessel_stub, "task", "TASKMANAGER", "edit")
+
+    server = grpc.server(
+        futures.ThreadPoolExecutor(max_workers=10),
+        interceptors=[view_interceptor],
+    )
+
+    servicer = TaskServicer(kessel_stub, db)
+
+    # Register your servicer with the gRPC server.
+    # In a real project this would be the generated registration function:
+    #   task_pb2_grpc.add_TaskServiceServicer_to_server(servicer, server)
+
+    server.add_insecure_port("[::]:8080")
+    logger.info("serving on :8080")
+    server.start()
+    server.wait_for_termination()
+    kessel_channel.close()
+
+
+# ---------------------------------------------------------------------------
+# Stubs (stand in for your protobuf-generated types and database layer)
+# ---------------------------------------------------------------------------
+
+class Task:
+    def __init__(self, id="", workspace_id="", title="", status="open"):
+        self.id = id
+        self.workspace_id = workspace_id
+        self.title = title
+        self.status = status
+
+class DeleteTaskResponse:
+    pass
+
+class DB:
+    def insert_task(self, request):
+        return Task()
+
+    def delete_task(self, task_id):
+        pass
+
+
+if __name__ == "__main__":
+    serve()

--- a/src/examples/integrate/main.py
+++ b/src/examples/integrate/main.py
@@ -8,6 +8,7 @@ from kessel.auth import OAuth2ClientCredentials, fetch_oidc_discovery
 from kessel.inventory.v1beta2 import (
     ClientBuilder,
     check_request_pb2,
+    delete_resource_request_pb2,
     report_resource_request_pb2,
     reporter_reference_pb2,
     representation_metadata_pb2,
@@ -93,21 +94,17 @@ class TaskServicer:
         self.db.delete_task(request.id)
 
         try:
-            self.kessel_stub.ReportResource(
-                report_resource_request_pb2.ReportResourceRequest(
-                    type="task",
-                    reporter_type="TASKMANAGER",
-                    reporter_instance_id=self.instance_id,
-                    representations=resource_representations_pb2.ResourceRepresentations(
-                        metadata=representation_metadata_pb2.RepresentationMetadata(
-                            local_resource_id=request.id,
-                            resource_deleted=True,
-                        ),
+            self.kessel_stub.DeleteResource(
+                delete_resource_request_pb2.DeleteResourceRequest(
+                    reference=resource_reference_pb2.ResourceReference(
+                        resource_type="task",
+                        resource_id=request.id,
+                        reporter=reporter_reference_pb2.ReporterReference(type="TASKMANAGER"),
                     ),
                 )
             )
         except grpc.RpcError as e:
-            logger.warning("kessel: failed to report task deletion %s: %s - %s", request.id, e.code(), e.details())
+            logger.warning("kessel: failed to delete task %s: %s - %s", request.id, e.code(), e.details())
 
         return DeleteTaskResponse()
 

--- a/src/examples/integrate/main.py
+++ b/src/examples/integrate/main.py
@@ -4,7 +4,6 @@ from concurrent import futures
 
 import grpc
 from google.protobuf import struct_pb2
-from kessel.auth import OAuth2ClientCredentials, fetch_oidc_discovery
 from kessel.inventory.v1beta2 import (
     ClientBuilder,
     check_request_pb2,
@@ -16,6 +15,7 @@ from kessel.inventory.v1beta2 import (
     resource_representations_pb2,
     subject_reference_pb2,
 )
+from kessel.inventory.v1beta2 import allowed_pb2
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
@@ -26,22 +26,9 @@ logger = logging.getLogger(__name__)
 # ---------------------------------------------------------------------------
 
 def create_kessel_client():
-    """Create an authenticated Kessel Inventory client using OAuth2 and TLS."""
-    discovery = fetch_oidc_discovery(os.getenv("KESSEL_ISSUER_URL"))
-
-    auth_credentials = OAuth2ClientCredentials(
-        client_id=os.getenv("KESSEL_CLIENT_ID"),
-        client_secret=os.getenv("KESSEL_CLIENT_SECRET"),
-        token_endpoint=discovery.token_endpoint,
-    )
-
-    with open(os.getenv("KESSEL_CA_CERT_PATH"), "rb") as f:
-        ca_cert = f.read()
-    ssl_credentials = grpc.ssl_channel_credentials(root_certificates=ca_cert)
-
     stub, channel = (
         ClientBuilder(os.getenv("KESSEL_ENDPOINT"))
-        .oauth2_client_authenticated(auth_credentials, ssl_credentials)
+        .insecure()
         .build()
     )
     return stub, channel
@@ -163,7 +150,7 @@ class KesselAuthInterceptor(grpc.ServerInterceptor):
                 lambda req, ctx: ctx.abort(grpc.StatusCode.PERMISSION_DENIED, "forbidden")
             )
 
-        if response.allowed != 1:  # ALLOWED_TRUE
+        if response.allowed != allowed_pb2.ALLOWED_TRUE:
             return grpc.unary_unary_rpc_method_handler(
                 lambda req, ctx: ctx.abort(grpc.StatusCode.PERMISSION_DENIED, "forbidden")
             )

--- a/src/examples/integrate/main.rb
+++ b/src/examples/integrate/main.rb
@@ -1,0 +1,157 @@
+require 'kessel-sdk'
+require 'json'
+
+include Kessel::Inventory::V1beta2
+
+# ---------------------------------------------------------------------------
+# Kessel client
+# ---------------------------------------------------------------------------
+
+def create_kessel_client
+  builder = KesselInventoryService::ClientBuilder.new(ENV.fetch('KESSEL_ENDPOINT', nil))
+  builder.insecure.build
+end
+
+# ---------------------------------------------------------------------------
+# Task service
+# ---------------------------------------------------------------------------
+
+class TaskServicer
+  def initialize(kessel_client, db, instance_id: nil)
+    @kessel_client = kessel_client
+    @db = db
+    @instance_id = instance_id || ENV.fetch('REPORTER_INSTANCE_ID', 'taskmanager-1')
+    @base_url = ENV.fetch('BASE_URL', 'http://localhost:8080')
+  end
+
+  def create_task(request, _call)
+    task = @db.insert_task(request)
+
+    common = Google::Protobuf::Struct.decode_json({ 'workspace_id' => task.workspace_id }.to_json)
+    reporter_data = Google::Protobuf::Struct.decode_json(
+      { 'title' => task.title, 'status' => task.status }.to_json
+    )
+
+    begin
+      @kessel_client.report_resource(
+        ReportResourceRequest.new(
+          type: 'task',
+          reporter_type: 'TASKMANAGER',
+          reporter_instance_id: @instance_id,
+          representations: ResourceRepresentations.new(
+            metadata: RepresentationMetadata.new(
+              local_resource_id: task.id,
+              api_href: "#{@base_url}/api/tasks/#{task.id}"
+            ),
+            common: common,
+            reporter: reporter_data
+          )
+        )
+      )
+    rescue GRPC::BadStatus => e
+      warn "kessel: failed to report task #{task.id}: #{e.message}"
+    end
+
+    task
+  end
+
+  def delete_task(request, _call)
+    @db.delete_task(request.id)
+
+    begin
+      @kessel_client.delete_resource(
+        DeleteResourceRequest.new(
+          reference: ResourceReference.new(
+            resource_type: 'task',
+            resource_id: request.id,
+            reporter: ReporterReference.new(type: 'TASKMANAGER')
+          )
+        )
+      )
+    rescue GRPC::BadStatus => e
+      warn "kessel: failed to delete task #{request.id}: #{e.message}"
+    end
+  end
+end
+
+# ---------------------------------------------------------------------------
+# Kessel auth interceptor
+# ---------------------------------------------------------------------------
+
+class KesselAuthInterceptor < GRPC::ServerInterceptor
+  def initialize(kessel_client, resource_type, reporter_type, relation)
+    @kessel_client = kessel_client
+    @resource_type = resource_type
+    @reporter_type = reporter_type
+    @relation = relation
+  end
+
+  def request_response(request:, call:, method:)
+    user_id = call.metadata['x-user-id']
+    resource_id = call.metadata['x-resource-id']
+
+    raise GRPC::PermissionDenied, 'missing user identity' unless user_id
+
+    response = @kessel_client.check(
+      CheckRequest.new(
+        object: ResourceReference.new(
+          resource_type: @resource_type,
+          resource_id: resource_id,
+          reporter: ReporterReference.new(type: @reporter_type)
+        ),
+        relation: @relation,
+        subject: SubjectReference.new(
+          resource: ResourceReference.new(
+            resource_type: 'principal',
+            resource_id: user_id,
+            reporter: ReporterReference.new(type: 'rbac')
+          )
+        )
+      )
+    )
+
+    raise GRPC::PermissionDenied, 'forbidden' unless response.allowed == Allowed::ALLOWED_TRUE
+
+    yield
+  rescue GRPC::Unavailable
+    raise GRPC::Unavailable, 'authorization service unavailable'
+  rescue GRPC::BadStatus
+    raise GRPC::PermissionDenied, 'forbidden'
+  end
+end
+
+# ---------------------------------------------------------------------------
+# Server startup
+# ---------------------------------------------------------------------------
+
+kessel_client = create_kessel_client
+db = DB.new
+
+view_interceptor = KesselAuthInterceptor.new(kessel_client, 'task', 'TASKMANAGER', 'view')
+edit_interceptor = KesselAuthInterceptor.new(kessel_client, 'task', 'TASKMANAGER', 'edit')
+
+server = GRPC::RpcServer.new(interceptors: [view_interceptor])
+server.add_http2_port('0.0.0.0:8080', :this_port_is_insecure)
+
+servicer = TaskServicer.new(kessel_client, db)
+
+# Register your servicer with the gRPC server.
+# In a real project this would use the generated service handler:
+#   server.handle(servicer)
+
+puts 'serving on :8080'
+server.run_till_terminated
+
+# ---------------------------------------------------------------------------
+# Stubs (stand in for your protobuf-generated types and database layer)
+# ---------------------------------------------------------------------------
+
+Task = Struct.new(:id, :workspace_id, :title, :status, keyword_init: true)
+
+class DB
+  def insert_task(request)
+    Task.new(id: '', workspace_id: '', title: '', status: 'open')
+  end
+
+  def delete_task(task_id) end
+end

--- a/src/examples/integrate/main.ts
+++ b/src/examples/integrate/main.ts
@@ -82,22 +82,16 @@ const deleteTask: handleUnaryCall<DeleteTaskRequest, DeleteTaskResponse> = async
 ) => {
     await db.deleteTask(call.request.id);
 
-    const reportRequest: ReportResourceRequest = {
-        type: "task",
-        reporterType: "TASKMANAGER",
-        reporterInstanceId: INSTANCE_ID,
-        representations: {
-            metadata: {
-                localResourceId: call.request.id,
-                resourceDeleted: true,
-            },
-        },
-    };
-
     try {
-        await kesselClient.reportResource(reportRequest);
+        await kesselClient.deleteResource({
+            reference: {
+                resourceType: "task",
+                resourceId: call.request.id,
+                reporter: { type: "TASKMANAGER" },
+            },
+        });
     } catch (err) {
-        console.warn(`kessel: failed to report task deletion ${call.request.id}:`, err);
+        console.warn(`kessel: failed to delete task ${call.request.id}:`, err);
     }
 
     callback(null, {});

--- a/src/examples/integrate/main.ts
+++ b/src/examples/integrate/main.ts
@@ -1,9 +1,7 @@
-import { readFileSync } from "fs";
 import {
     Server,
     ServerCredentials,
     Metadata,
-    credentials,
     status as grpcStatus,
 } from "@grpc/grpc-js";
 import type {
@@ -13,7 +11,7 @@ import type {
     ServerInterceptingCall,
 } from "@grpc/grpc-js";
 import { ClientBuilder } from "@project-kessel/kessel-sdk/kessel/inventory/v1beta2";
-import { fetchOIDCDiscovery, OAuth2ClientCredentials } from "@project-kessel/kessel-sdk/kessel/auth";
+import { Allowed } from "@project-kessel/kessel-sdk/kessel/inventory/v1beta2/allowed";
 import type { CheckRequest } from "@project-kessel/kessel-sdk/kessel/inventory/v1beta2/check_request";
 import type { ReportResourceRequest } from "@project-kessel/kessel-sdk/kessel/inventory/v1beta2/report_resource_request";
 
@@ -21,24 +19,9 @@ import type { ReportResourceRequest } from "@project-kessel/kessel-sdk/kessel/in
 // Kessel client
 // ---------------------------------------------------------------------------
 
-async function createKesselClient() {
-    const discovery = await fetchOIDCDiscovery(process.env.KESSEL_ISSUER_URL!);
-
-    const auth = new OAuth2ClientCredentials({
-        clientId: process.env.KESSEL_CLIENT_ID!,
-        clientSecret: process.env.KESSEL_CLIENT_SECRET!,
-        tokenEndpoint: discovery.tokenEndpoint,
-    });
-
-    const caCert = readFileSync(process.env.KESSEL_CA_CERT_PATH!);
-    const tlsCreds = credentials.createSsl(caCert);
-
-    return new ClientBuilder(process.env.KESSEL_ENDPOINT!)
-        .oauth2ClientAuthenticated(auth, tlsCreds)
-        .buildAsync();
-}
-
-const kesselClient = await createKesselClient();
+const kesselClient = new ClientBuilder(process.env.KESSEL_ENDPOINT!)
+    .insecure()
+    .buildAsync();
 
 const INSTANCE_ID = process.env.REPORTER_INSTANCE_ID ?? "taskmanager-1";
 const BASE_URL = process.env.BASE_URL ?? "http://localhost:8080";
@@ -142,7 +125,7 @@ function kesselAuthInterceptor(
 
         try {
             const response = await client.check(checkRequest);
-            if (response.allowed !== 1) { // ALLOWED_TRUE
+            if (response.allowed !== Allowed.ALLOWED_TRUE) {
                 call.sendStatus({
                     code: grpcStatus.PERMISSION_DENIED,
                     details: "forbidden",

--- a/src/examples/integrate/main.ts
+++ b/src/examples/integrate/main.ts
@@ -1,18 +1,26 @@
 import { readFileSync } from "fs";
-import { ClientBuilder } from "@project-kessel/kessel-sdk/kessel/inventory/v1beta2";
-import { fetchOIDCDiscovery, OAuth2ClientCredentials } from "@project-kessel/kessel-sdk/kessel/auth";
-import type { CheckRequest } from "@project-kessel/kessel-sdk/kessel/inventory/v1beta2/check_request";
-import type { ReportResourceRequest } from "@project-kessel/kessel-sdk/kessel/inventory/v1beta2/report_resource_request";
+import {
+    Server,
+    ServerCredentials,
+    Metadata,
+    credentials,
+    status as grpcStatus,
+} from "@grpc/grpc-js";
 import type {
     ServerUnaryCall,
     sendUnaryData,
     handleUnaryCall,
-    Metadata,
     ServerInterceptingCall,
 } from "@grpc/grpc-js";
-import { credentials, status as grpcStatus } from "@grpc/grpc-js";
+import { ClientBuilder } from "@project-kessel/kessel-sdk/kessel/inventory/v1beta2";
+import { fetchOIDCDiscovery, OAuth2ClientCredentials } from "@project-kessel/kessel-sdk/kessel/auth";
+import type { CheckRequest } from "@project-kessel/kessel-sdk/kessel/inventory/v1beta2/check_request";
+import type { ReportResourceRequest } from "@project-kessel/kessel-sdk/kessel/inventory/v1beta2/report_resource_request";
 
-//#region client-setup
+// ---------------------------------------------------------------------------
+// Kessel client
+// ---------------------------------------------------------------------------
+
 async function createKesselClient() {
     const discovery = await fetchOIDCDiscovery(process.env.KESSEL_ISSUER_URL!);
 
@@ -29,27 +37,30 @@ async function createKesselClient() {
         .oauth2ClientAuthenticated(auth, tlsCreds)
         .buildAsync();
 }
-//#endregion
 
 const kesselClient = await createKesselClient();
 
-//#region report-on-create
+const INSTANCE_ID = process.env.REPORTER_INSTANCE_ID ?? "taskmanager-1";
+const BASE_URL = process.env.BASE_URL ?? "http://localhost:8080";
+
+// ---------------------------------------------------------------------------
+// Task service handlers
+// ---------------------------------------------------------------------------
+
 const createTask: handleUnaryCall<CreateTaskRequest, CreateTaskResponse> = async (
     call: ServerUnaryCall<CreateTaskRequest, CreateTaskResponse>,
     callback: sendUnaryData<CreateTaskResponse>
 ) => {
-    // --- Your existing service logic ---
     const task = await db.insertTask(call.request);
 
-    // --- Report to Kessel ---
     const reportRequest: ReportResourceRequest = {
         type: "task",
         reporterType: "TASKMANAGER",
-        reporterInstanceId: process.env.REPORTER_INSTANCE_ID ?? "taskmanager-1",
+        reporterInstanceId: INSTANCE_ID,
         representations: {
             metadata: {
                 localResourceId: task.id,
-                apiHref: `${process.env.BASE_URL}/api/tasks/${task.id}`,
+                apiHref: `${BASE_URL}/api/tasks/${task.id}`,
             },
             common: { workspace_id: task.workspaceId },
             reporter: { title: task.title, status: task.status },
@@ -59,18 +70,45 @@ const createTask: handleUnaryCall<CreateTaskRequest, CreateTaskResponse> = async
     try {
         await kesselClient.reportResource(reportRequest);
     } catch (err) {
-        // Log but don't fail. The resource exists in your database;
-        // Kessel will catch up on the next report or reconciliation.
         console.warn(`kessel: failed to report task ${task.id}:`, err);
     }
 
     callback(null, { task });
 };
-//#endregion
 
-//#region check-middleware
+const deleteTask: handleUnaryCall<DeleteTaskRequest, DeleteTaskResponse> = async (
+    call: ServerUnaryCall<DeleteTaskRequest, DeleteTaskResponse>,
+    callback: sendUnaryData<DeleteTaskResponse>
+) => {
+    await db.deleteTask(call.request.id);
+
+    const reportRequest: ReportResourceRequest = {
+        type: "task",
+        reporterType: "TASKMANAGER",
+        reporterInstanceId: INSTANCE_ID,
+        representations: {
+            metadata: {
+                localResourceId: call.request.id,
+                resourceDeleted: true,
+            },
+        },
+    };
+
+    try {
+        await kesselClient.reportResource(reportRequest);
+    } catch (err) {
+        console.warn(`kessel: failed to report task deletion ${call.request.id}:`, err);
+    }
+
+    callback(null, {});
+};
+
+// ---------------------------------------------------------------------------
+// Kessel auth interceptor
+// ---------------------------------------------------------------------------
+
 function kesselAuthInterceptor(
-    kesselClient: Awaited<ReturnType<typeof createKesselClient>>,
+    client: typeof kesselClient,
     resourceType: string,
     reporterType: string,
     relation: string
@@ -109,7 +147,7 @@ function kesselAuthInterceptor(
         };
 
         try {
-            const response = await kesselClient.check(checkRequest);
+            const response = await client.check(checkRequest);
             if (response.allowed !== 1) { // ALLOWED_TRUE
                 call.sendStatus({
                     code: grpcStatus.PERMISSION_DENIED,
@@ -136,18 +174,43 @@ function kesselAuthInterceptor(
     };
 }
 
-// Wire it up when creating the gRPC server:
-//
-//   const server = new grpc.Server({
-//       interceptors: [
-//           kesselAuthInterceptor(kesselClient, "task", "TASKMANAGER", "view"),
-//       ],
-//   });
-//   server.addService(TaskServiceDefinition, { createTask });
-//#endregion
+// ---------------------------------------------------------------------------
+// Server startup
+// ---------------------------------------------------------------------------
 
-// Type stubs for compilation context.
+const server = new Server({
+    interceptors: [
+        kesselAuthInterceptor(kesselClient, "task", "TASKMANAGER", "view"),
+    ],
+});
+
+// Register your service with the gRPC server.
+// In a real project this would use the generated service definition:
+//   server.addService(TaskServiceDefinition, { createTask, deleteTask });
+
+server.bindAsync(
+    "0.0.0.0:8080",
+    ServerCredentials.createInsecure(),
+    (err, port) => {
+        if (err) {
+            console.error("failed to bind:", err);
+            process.exit(1);
+        }
+        console.log(`serving on :${port}`);
+    }
+);
+
+// ---------------------------------------------------------------------------
+// Stubs (stand in for your protobuf-generated types and database layer)
+// ---------------------------------------------------------------------------
+
 interface CreateTaskRequest { title: string; workspaceId: string }
 interface CreateTaskResponse { task: Task }
+interface DeleteTaskRequest { id: string }
+interface DeleteTaskResponse {}
 interface Task { id: string; workspaceId: string; title: string; status: string }
-const db = { insertTask: async (req: CreateTaskRequest): Promise<Task> => ({} as Task) };
+
+const db = {
+    insertTask: async (req: CreateTaskRequest): Promise<Task> => ({} as Task),
+    deleteTask: async (id: string): Promise<void> => {},
+};

--- a/src/examples/integrate/task/common_representation.json
+++ b/src/examples/integrate/task/common_representation.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "properties": {
+    "workspace_id": { "type": "string" }
+  },
+  "required": [
+    "workspace_id"
+  ]
+}

--- a/src/examples/integrate/task/config.yaml
+++ b/src/examples/integrate/task/config.yaml
@@ -1,0 +1,3 @@
+resource_type: task
+resource_reporters:
+  - TASKMANAGER

--- a/src/examples/integrate/task/reporters/taskmanager/config.yaml
+++ b/src/examples/integrate/task/reporters/taskmanager/config.yaml
@@ -1,0 +1,3 @@
+resource_type: task
+reporter_name: TASKMANAGER
+namespace: taskmanager

--- a/src/examples/integrate/task/reporters/taskmanager/task.json
+++ b/src/examples/integrate/task/reporters/taskmanager/task.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "properties": {
+    "title": { "type": "string" },
+    "status": {
+      "type": "string",
+      "enum": ["open", "in_progress", "done"]
+    },
+    "assignee_id": { "type": "string" },
+    "created_at": {
+      "type": "string",
+      "format": "date-time"
+    }
+  },
+  "required": [
+    "title",
+    "status"
+  ]
+}

--- a/src/examples/integrate/taskmanager.ksl
+++ b/src/examples/integrate/taskmanager.ksl
@@ -1,0 +1,14 @@
+version 0.1
+namespace taskmanager
+
+import rbac
+
+@rbac.add_permission(name:'task_view')
+@rbac.add_permission(name:'task_edit')
+
+public type task {
+    relation workspace: [ExactlyOne rbac.workspace]
+
+    relation view: workspace.task_view
+    relation edit: workspace.task_edit
+}


### PR DESCRIPTION
For RHCLOUD-47190, the goal was to create a tutorial that could target developers who have an existing service and need to add Kessel authorization to it. It expands a bit more on the quick start and hopefully functions as a way to build users chops with Kessel

Changes:
* Update Quick Start to add time estimate and "What you learned" summary (Diataxis alignment)
* Adds new "Add Kessel to an existing application" tutorial under Start Here
  * New tutorial cross-references how-to guides without duplicating content and expands on whats learned in quick start
  * the goal is to  focus on integration seams (SDK client setup, reporting at CRUD boundaries, permission checking via interceptors) instead of duplicating the Quick Start's walkthrough
  * to drive learning, it doesnt outright provide examples of the schema files or code so that users can try without assistance BUT examples are provided and linked in case they get stuck