### PR TITLE
RHCLOUD-47197: adds link checker CI to monitor for broken/stale links in docs

### DIFF
--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -1,0 +1,55 @@
+name: Link Check
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'src/content/docs/**'
+  schedule:
+    # Weekly Monday morning — catch link rot between PRs
+    - cron: '17 8 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  check-links:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Check documentation links
+        uses: lycheeverse/lychee-action@v2
+        with:
+          args: >-
+            -vv
+            --config .lychee.toml
+            "src/content/docs/**/*.md"
+            "src/content/docs/**/*.mdx"
+          # Use GITHUB_TOKEN to avoid rate limits on github.com links
+          token: ${{ secrets.GITHUB_TOKEN }}
+          fail: true
+
+      - name: Notify on scheduled run failure
+        if: failure() && github.event_name == 'schedule'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const title = 'Link check: broken links detected';
+            const issues = await github.rest.issues.listForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+              labels: 'link-rot',
+            });
+            if (issues.data.length === 0) {
+              await github.rest.issues.create({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                title,
+                body: `The weekly link check found broken links.\n\nSee the [workflow run](${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}) for details.`,
+                labels: ['link-rot'],
+              });
+            }

--- a/.lychee.toml
+++ b/.lychee.toml
@@ -1,0 +1,86 @@
+# Lychee link checker configuration
+# https://lychee.cli.rs/usage/config/
+#
+# This config is used by both CI (GitHub Actions) and local runs via
+# ./scripts/check-links.sh. It checks all external URLs in documentation
+# pages under src/content/docs/ and flags broken links.
+#
+# WHAT THIS CHECKS:
+#   - External HTTP/HTTPS links in .md and .mdx files
+#
+# WHAT THIS SKIPS:
+#   - Internal site links (relative/root-relative Astro routes)
+#   - Email addresses
+#   - Links to excluded domains (see exclude list below)
+#
+# HOW ROOT-RELATIVE LINKS WORK:
+#   Markdown files in this repo use root-relative links like
+#   /docs/building-with-kessel/concepts/rbac/ which are Astro routes.
+#   Lychee can't resolve these from source files, so we set base_url to
+#   convert them into full URLs, then exclude the site domain so they're
+#   skipped without any network requests. This avoids false "Cannot resolve
+#   root-relative link" errors.
+#
+# ADDING A NEW EXCLUDED DOMAIN:
+#   1. Add a regex pattern to the appropriate section in the exclude list
+#   2. Escape dots with \\ (e.g., "new\\.domain\\.com")
+#   3. Run ./scripts/check-links.sh to verify it's excluded
+#   4. Add a comment explaining WHY it's excluded (auth, blocks bots, etc.)
+
+include_mail = false
+scheme = ["https", "http"]
+base_url = "https://project-kessel.github.io"
+
+exclude = [
+  # ---- Internal site links ----
+  # Resolved via base_url above, then skipped to avoid network requests.
+  # DO NOT REMOVE — without this, every internal cross-reference would be
+  # checked as an HTTP request against the live site.
+  "project-kessel\\.github\\.io",
+
+  # ---- Red Hat internal (auth/VPN required) ----
+  # Broad patterns to match internal/staging infrastructure without
+  # exposing specific hostnames in this public repo.
+  "\\.stage\\.",                           # Staging environments
+  "\\.cee\\.",                             # Internal corporate domains
+  "\\.atlassian\\.net",                    # Atlassian-hosted tools
+  "issues\\.redhat\\.",                    # Issue tracker
+
+  # ---- Google (authenticated) ----
+  # Google Docs/Drive/Meet links require account auth.
+  # Found in: various planning and reference docs
+  "docs\\.google\\.com",
+
+  # ---- Sites that block automated requests ----
+  # These sites return 403 to bots/crawlers regardless of link validity.
+  # Found in: client-libraries.mdx, setup-sdk-for-ci.mdx
+  "www\\.npmjs\\.com",
+  "blogs\\.oracle\\.com",
+
+  # ---- Local and example domains ----
+  # Used in code examples and configuration snippets. Not real URLs.
+  # Found in: getting-started.mdx, configure-authentication.mdx, and
+  #           various code examples throughout
+  "localhost",
+  "127\\.0\\.0\\.1",
+  "0\\.0\\.0\\.0",
+  "example\\.com",
+  "example\\.org",
+  "sso\\.example\\.com",
+  "acs\\.example\\.com",
+]
+
+# Only treat HTTP 200 and 429 (rate-limited) as success.
+# 429 is accepted because it means the link exists but we hit a rate limit.
+accept = [200, 429]
+
+timeout = 30
+max_retries = 3
+max_concurrency = 8
+
+# Cap redirects to avoid following SSO login chains indefinitely
+max_redirects = 5
+
+# NOTE: GitHub rate-limits unauthenticated requests heavily.
+# In CI, the GitHub Actions workflow passes GITHUB_TOKEN to avoid 429s.
+# Locally, export GITHUB_TOKEN to get the same benefit.

--- a/README.md
+++ b/README.md
@@ -59,6 +59,39 @@ config-overlay.mjs          # Fork/overlay hooks for internal documentation
 
 This repository is designed to be forked for internal documentation. The `config-overlay.mjs` file provides hook functions to modify the Astro and Starlight configuration (e.g., adding sidebar entries for internal docs) without altering upstream files. See [CONTRIBUTING.md](CONTRIBUTING.md) for details.
 
+## Link Checking
+
+External links in documentation are checked automatically using [lychee](https://github.com/lycheeverse/lychee), a fast link checker written in Rust. This catches broken links, moved pages, and dead URLs before they rot.
+
+### How it runs
+
+- **On pull requests**: checks links in changed docs automatically via GitHub Actions
+- **Weekly schedule**: runs every Monday morning to catch link rot between PRs
+- **On failure**: scheduled runs auto-create a GitHub issue with the `link-rot` label
+
+### Running locally
+
+Install [lychee](https://github.com/lycheeverse/lychee#installation), then run the check script:
+
+```bash
+./scripts/check-links.sh
+```
+
+### What gets checked
+
+The checker only validates external HTTP/HTTPS links in `src/content/docs/`. Internal cross-references (root-relative Astro routes like `/docs/building-with-kessel/...`) are skipped since they can't be resolved from source files.
+
+### Excluding a domain
+
+Some domains need to be excluded because they require authentication, block automated requests, or are placeholders in code examples. To add a new exclusion:
+
+1. Edit `.lychee.toml` and add a regex pattern to the appropriate section
+2. Escape dots with `\\` (e.g., `"new\\.domain\\.com"`)
+3. Add a comment explaining why it's excluded
+4. Run `./scripts/check-links.sh` to verify
+
+See `.lychee.toml` for the full list of excluded domains and the reasons for each.
+
 ## Further Reading
 
 | Resource | Description |

--- a/scripts/check-links.sh
+++ b/scripts/check-links.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# Check documentation links using lychee.
+#
+# Usage:
+#   ./scripts/check-links.sh           # check all doc pages
+#   ./scripts/check-links.sh --verbose  # with detailed output
+#
+# Install lychee:
+#   brew install lychee          (macOS)
+#   cargo install lychee         (Rust/cargo)
+#   dnf install lychee           (Fedora)
+#   Or grab a binary from https://github.com/lycheeverse/lychee/releases
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+
+if ! command -v lychee &>/dev/null; then
+  echo "Error: lychee is not installed."
+  echo "Install it via: brew install lychee | cargo install lychee | dnf install lychee"
+  echo "Or download from https://github.com/lycheeverse/lychee/releases"
+  exit 1
+fi
+
+echo "Checking links in src/content/docs/ ..."
+
+lychee -vv\
+  --config "${REPO_ROOT}/.lychee.toml" \
+  "$@" \
+  "${REPO_ROOT}/src/content/docs/**/*.md" \
+  "${REPO_ROOT}/src/content/docs/**/*.mdx"


### PR DESCRIPTION
Whats New:
* Adds automated external link checking using lychee (Rust binary) to catch broken/stale URLs in documentation
  *  configured with exclude list for auth-gated, bot-blocked, and placeholder domains, as well as relative paths
  * new workflow runs on PRs that touch docs and weekly on a schedule
  * Auto-creates an issue in Github with link-rot label on scheduled run failures
* adds new script `check-links.sh` which allows for testing locally and mimics the Github workflow
