### PR TITLE
adds back the For Red Hatters page

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -118,7 +118,8 @@ const baseStarlightConfig = {
           autogenerate: { directory: 'contributing/client-api' }
         }
       ]
-    }
+    },
+    "for-red-hatters",
   ],
   components: {
     // Overridden to template out client package descriptions based on frontmatter.

--- a/src/content/docs/for-red-hatters.md
+++ b/src/content/docs/for-red-hatters.md
@@ -1,6 +1,8 @@
 ---
 title: For Red Hatters
 description: Information for Red Hatters about using Kessel.
+prev: false
+next: false
 ---
 
 Kessel is an open source project also deployed internally. To learn more about leveraging Kessel


### PR DESCRIPTION
Adds back the "For Red Hatters" page with info on internal guides in InScope, the page was accidentally removed when the config-ovverlay.mjs file was removed in https://github.com/project-kessel/docs/pull/109/changes