### PR TITLE
Update internal docs link in for-red-hatters.md

### DIFF
--- a/src/content/docs/for-red-hatters.md
+++ b/src/content/docs/for-red-hatters.md
@@ -6,4 +6,4 @@ next: false
 ---
 
 Kessel is an open source project also deployed internally. To learn more about leveraging Kessel
-internally as well as Red Hat-specific examples and configurations, see our internal docs in **inScope**
+internally as well as Red Hat-specific examples and configurations, see our internal docs in [**inScope**](https://inscope.corp.redhat.com/docs/default/component/kessel-internal-docs)


### PR DESCRIPTION
Adding the InScope documentation link to the Internal Docs "For Red Hatters" reference page. 