### PR TITLE
removes installation path until there is a need for it

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -95,11 +95,6 @@ const baseStarlightConfig = {
       items: [
         'running-kessel/architecture',
         {
-          label: "Installation",
-          collapsed: true,
-          autogenerate: { directory: 'running-kessel/installation' }
-        },
-        {
           label: "Monitoring Kessel",
           collapsed: true,
           autogenerate: { directory: 'running-kessel/monitoring-kessel' }


### PR DESCRIPTION
Removes the installation  section until we have a more definitive on-prem effort. Its unlikely anyone would install kessel services vs run them in containers until we focus on on-prem and possibly server implementations. This just keeps the docs free of empty pages/sections. Should we need this section in the future, it can be tracked in that effort