### PR TITLE
RHCLOUD-48848: adds path_instructions for use by sp's for code review

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -67,8 +67,10 @@ reviews:
           (not "write") as the verb.
 
         Error handling:
-        - Catch the SDK's gRPC error type specifically. Do not catch
-          a generic exception or error type for gRPC calls.
+        - Catch the SDK's gRPC error type specifically. If the SDK
+          does not expose a typed error class, catch generically but
+          narrow the caught value to the gRPC error type and handle
+          by status code before any other logic.
         - Do not wrap gRPC errors in custom SDK error types.
         - Match on gRPC status code, not message text. Messages
           marked "variable" change across versions.

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -4,9 +4,155 @@ knowledge_base:
   learnings:
     scope: global
   code_guidelines:
+    enabled: true
     filePatterns:
       - "**/AGENTS.md"
       - "**/CLAUDE.md"
       - "**/CONTRIBUTING.md"
       - "**/GUIDELINES.md"
       - "KESSEL-INTEGRATION-GUIDE.md"
+
+# Path instructions travel via remote_config to service provider repos.
+# Service providers inherit these by adding remote_config pointing here.
+# See KESSEL-INTEGRATION-GUIDE.md "CodeRabbit Setup for Service Providers" for details.
+#
+# Design constraints (from KSL-060):
+# - Stay under 10-12 total instructions to avoid diminishing returns
+# - Use Kessel-specific paths to avoid collisions with local configs
+# - Keep instructions actionable (things CodeRabbit can flag in a diff)
+reviews:
+  path_instructions:
+    # Kessel integration files -- detailed review rules.
+    # Matches files with "kessel" in the name (e.g. lib/kessel.py,
+    # kessel_client.go, test_kessel.py). Near-zero collision risk
+    # with service provider local configs.
+    - path: "**/*kessel*"
+      instructions: |
+        Kessel integration code. Apply these rules during review:
+
+        API version:
+        - Current version is v1beta2. Flag any v1beta1 references as
+          deprecated unless the code is explicitly marked as legacy/migration.
+
+        Client construction:
+        - Use the SDK ClientBuilder pattern. Do not construct gRPC
+          channels or stubs manually.
+        - Reuse client and channel instances across requests. Creating
+          a new channel per request wastes resources and connections.
+        - Call insecure() only for local development. Flag insecure
+          channels in production or staging code paths.
+
+        Authentication:
+        - Use OAuth2ClientCredentials from the SDK auth package.
+          Token caching and automatic refresh are built in -- do
+          not add manual token caching or refresh logic.
+        - Read credentials from environment variables or secure config,
+          never hardcoded.
+
+        Authorization checks:
+        - Use Check for read operations and permission filtering.
+        - Use CheckForUpdate for write operations and sensitive reads
+          (e.g. reading credentials). It provides stronger consistency.
+          Call it right before the write -- do not cache the result.
+        - Bulk endpoints (CheckBulk, CheckSelfBulk) can succeed at
+          the RPC level while individual items fail. Always check
+          per-item errors in the response pairs.
+        - CheckBulk accepts up to 1000 items per RPC. For larger
+          sets, batch into multiple calls.
+
+        Permission naming:
+        - Permissions follow the format {app}_{resource}_{verb}
+          (e.g. myservice_integration_view).
+        - V2 naming convention: use "view" (not "read") and "edit"
+          (not "write") as the verb.
+
+        Error handling:
+        - Catch the SDK's gRPC error type specifically. Do not catch
+          a generic exception or error type for gRPC calls.
+        - Do not wrap gRPC errors in custom SDK error types.
+        - Match on gRPC status code, not message text. Messages
+          marked "variable" change across versions.
+        - UNAVAILABLE and DEADLINE_EXCEEDED are retryable with
+          exponential backoff. INVALID_ARGUMENT, NOT_FOUND, and
+          PERMISSION_DENIED are not retryable -- fix the request.
+        - Check returning allowed=false is a successful response,
+          NOT an error. PERMISSION_DENIED means meta-authorization
+          failure (the caller cannot perform the RPC itself). Do
+          not confuse the two.
+
+        Failure handling:
+        - When Kessel is unavailable, fail closed (deny access) as
+          the secure default. Log the error for monitoring.
+        - A Kessel outage should not prevent your service from
+          creating or modifying its own resources. Report failures
+          should be logged and reconciled later, not block the
+          user's request.
+
+        Subject construction:
+        - User principals use resource_type "principal" with
+          resource_id "{domain}/{user_id}" and reporter.type "rbac".
+        - Use SDK helper functions for building subject and resource
+          references instead of constructing protobuf objects manually.
+
+        Workspace lookups:
+        - When calling RBAC workspace APIs, authenticate with the
+          service's own OAuth token. Do not relay the end-user's
+          x-rh-identity header -- the user may lack workspace
+          listing permissions.
+        - Set x-rh-rbac-org-id header for org-scoped lookups.
+
+        Resource reporting:
+        - Report resources after the database write, not before.
+          The resource must exist in your system before Kessel
+          knows about it.
+        - Include workspace_id in the common representation. This
+          connects the resource to the workspace hierarchy and
+          enables permission inheritance.
+        - ReportResource succeeds at the API level even if the
+          resource type has no matching schema in SpiceDB. The
+          failure surfaces asynchronously during replication. When
+          introducing a new resource type, verify it is defined in
+          the loaded schema or authorization checks will fail.
+        - Use write_visibility IMMEDIATE only when the caller needs
+          to Check the resource immediately after reporting it.
+          It adds 100-500ms latency.
+
+        Consistency and replication:
+        - Do not add sleep() or artificial delays after reporting
+          a resource. Use write_visibility IMMEDIATE for read-after-
+          write guarantees, or at_least_as_fresh with a consistency
+          token from a prior write for causal ordering.
+        - Replication from inventory DB to authorization graph is
+          typically 100-500ms. Design UX to handle this window
+          (optimistic UI, processing indicator) rather than blocking.
+
+        List endpoint authorization:
+        - Prefer pre-filtering with StreamedListObjects: get the
+          user's accessible workspace IDs first, then query your DB
+          with WHERE workspace_id IN (...). This scales better than
+          fetching everything and post-filtering.
+        - Use CheckBulk for batch authorization checks, not a loop
+          of individual Check calls.
+
+        Resource cleanup:
+        - Close gRPC channels and connections during shutdown to
+          prevent resource leaks and process hangs.
+
+    # Broad catch-all for files that use Kessel indirectly (e.g.
+    # config files with KESSEL_* env vars, auth modules importing
+    # Kessel types). Kept very short to minimize context overhead.
+    - path: "**"
+      instructions: |
+        If this code imports or calls a Kessel SDK package
+        (any project-kessel SDK for Go, Python, Ruby, Java, Node,
+        or Browser):
+        - Use v1beta2 API version (v1beta1 is deprecated)
+        - Use the SDK ClientBuilder for client construction
+        - Do not hardcode credentials -- use environment variables
+          or secure configuration
+        - Use Check for reads, CheckForUpdate for writes
+        - Do not add sleep() delays after reporting resources --
+          use write_visibility IMMEDIATE or consistency tokens
+        - Fail closed (deny access) when Kessel is unavailable
+        - See project-kessel/docs KESSEL-INTEGRATION-GUIDE.md for
+          full conventions

--- a/KESSEL-INTEGRATION-GUIDE.md
+++ b/KESSEL-INTEGRATION-GUIDE.md
@@ -2,7 +2,7 @@
 
 This guide consolidates consumer and integrator knowledge for teams building on the Kessel platform. It covers API contracts, SDK conventions, authentication, authorization, database schema, data replication, and monitoring patterns.
 
-This content is leveraged by CodeRabbit for context during PR reviews. Eventually it will be distilled into CodeRabbit `path_instructions` for targeted review guidance in service provider code bases.
+This content is leveraged by CodeRabbit for context during PR reviews. Key rules are distilled into `path_instructions` in this repo's `.coderabbit.yaml`, which service providers can inherit via `remote_config` (see "CodeRabbit Setup for Service Providers" below).
 
 ## Platform Architecture
 
@@ -538,3 +538,38 @@ Kessel Inventory writes two outbox event types per resource operation. After Deb
 - All SDK examples demonstrate the same scenario with identical resource data across languages.
 - Async messaging examples (Kafka consumers, outbox pattern) use the Go `confluent-kafka-go` library as the reference implementation.
 - SASL authentication with SCRAM-SHA-512 is the standard for Kafka consumers.
+
+## CodeRabbit Setup for Service Providers
+
+Service providers integrating with Kessel can opt in to Kessel-aware CodeRabbit reviews by inheriting this repo's configuration. This delivers Kessel integration rules (API version, ClientBuilder usage, error handling, auth patterns) to PRs in your repo without maintaining Kessel-specific guideline files locally.
+
+### Setup
+
+Add the following to your repo's `.coderabbit.yaml` (create the file if it does not exist):
+
+```yaml
+inheritance: true
+remote_config:
+  repository: "project-kessel/docs"
+  ref: "main"
+  path: ".coderabbit.yaml"
+```
+
+With `inheritance: true`, CodeRabbit deep-merges the remote and local configs:
+
+- **Scalar settings** (language, profile): local wins.
+- **Object settings** (reviews.auto_review): deep merge, local properties override matching remote properties.
+- **Array settings** (path_instructions): local entries first, unique remote entries appended, deduplicated by path key.
+
+Your existing review rules remain intact. Kessel `path_instructions` are appended for paths you have not already defined. If you have a local rule for the same path key, your local rule takes precedence.
+
+### What you get
+
+Two sets of review rules are inherited:
+
+1. **`**/*kessel*`** -- Detailed rules applied to files with "kessel" in the name. Covers API version, ClientBuilder usage, auth, error handling, authorization checks, subject construction, and resource cleanup.
+2. **`**`** -- A short conditional reminder applied broadly: if the file imports Kessel SDK packages, use v1beta2, use ClientBuilder, and don't hardcode credentials.
+
+### Verification
+
+Comment `@coderabbitai configuration` on any PR in your repo to see the fully resolved configuration with source annotations showing which level supplied each value (repository YAML, remote config, defaults).


### PR DESCRIPTION
What Changed:
Add CodeRabbit `path_instructions` for use by service provider repos
* Add `reviews.path_instructions` to `.coderabbit.yaml` with two language-agnostic rule sets: 
    * a detailed `**/*kessel*` instruction (13 review topics covering API version, ClientBuilder, auth, error handling, consistency, resource reporting, and more)
    * a short ** catch-all for files that import Kessel SDKs indirectly
* Add "CodeRabbit Setup for Service Providers" section to `KESSEL-INTEGRATION-GUIDE.md` with the `remote_config` snippet, merge behavior, and verification steps
* Update integration guide intro to reflect that `path_instructions` are now live

Design notes:
* Uses **/*kessel* path to avoid collisions with service provider local configs (language-specific globs like **/*.go would be silently dropped if the provider defines the same path key)
* Stays at 2 path instruction entries, well under the 10-12 scalability threshold
* All rules are SDK/language-agnostic -- no Python, Go, or Java-specific references

Why:

Review KSL-060 for more details, but the hope is that service providers integrating with Kessel for the first time have no Kessel domain knowledge in their repos for CodeRabbit to leverage. These path_instructions travel via remote_config to any repo that opts in, giving teams Kessel-aware review coverage without maintaining guideline files locally. This can help onboarding teams during initial integration setup without the need for Kessel team reviews and guidance, increase self-service capabilities. 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added guidance for enabling Kessel-aware CodeRabbit reviews in service provider repositories.
  * Documented how inherited and local review settings are merged and verified.
* **Chores**
  * Expanded automated code review guidance for Kessel integrations, including API versioning expectations, SDK client construction, OAuth/authorization handling, gRPC error behavior and retryability, bulk/pagination semantics, resource reporting visibility, and shutdown cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->